### PR TITLE
excluding pnpm-lock.yaml from git diff

### DIFF
--- a/aicommits.ts
+++ b/aicommits.ts
@@ -28,7 +28,7 @@ export async function main() {
   }
 
   const diff = execSync(
-    "git diff --cached . ':(exclude)package-lock.json' ':(exclude)yarn.lock'",
+    "git diff --cached . ':(exclude)package-lock.json' ':(exclude)yarn.lock' ':(exclude)pnpm-lock.yaml'",
     {
       encoding: "utf8",
     }


### PR DESCRIPTION
Such an awesome tool, thanks for this 🙌

This PR adds the lockfile from `pnpm` to the git diff exclusion list.