### PR TITLE
Update execSync command to use backticks instead of single quotes.

### DIFF
--- a/aicommits.ts
+++ b/aicommits.ts
@@ -28,7 +28,7 @@ export async function main() {
   }
 
   const diff = execSync(
-    "git diff --cached . ':(exclude)package-lock.json' ':(exclude)yarn.lock'",
+    `git diff --cached . ":(exclude)package-lock.json" ":(exclude)yarn.lock"`,
     {
       encoding: "utf8",
     }


### PR DESCRIPTION
Windows is not happy with single quote inside `execSync` 
Fixing #7 