### PR TITLE
fix: added naive error handling for OpenAI API Calls

### DIFF
--- a/aicommits.ts
+++ b/aicommits.ts
@@ -55,30 +55,36 @@ export async function main() {
   console.log(
     chalk.white("▲ ") + chalk.gray("Generating your AI commit message...\n")
   );
-  const aiCommitMessage = await generateCommitMessage(prompt);
 
-  console.log(
-    chalk.white("▲ ") + chalk.bold("Commit message: ") + aiCommitMessage + "\n"
-  );
 
-  const confirmationMessage = await inquirer.prompt([
-    {
-      name: "useCommitMessage",
-      message: "Would you like to use this commit message? (Y / n)",
-      choices: ["Y", "y", "n"],
-      default: "y",
-    },
-  ]);
+  try {
+    const aiCommitMessage = await generateCommitMessage(prompt);
 
-  if (confirmationMessage.useCommitMessage === "n") {
-    console.log(chalk.white("▲ ") + "Commit message has not been commited.");
-    process.exit(1);
-  }
+    console.log(
+      chalk.white("▲ ") + chalk.bold("Commit message: ") + aiCommitMessage + "\n"
+    );
 
-  execSync(`git commit -m "${aiCommitMessage}"`, {
-    stdio: "inherit",
-    encoding: "utf8",
-  });
+    const confirmationMessage = await inquirer.prompt([
+      {
+        name: "useCommitMessage",
+        message: "Would you like to use this commit message? (Y / n)",
+        choices: ["Y", "y", "n"],
+        default: "y",
+      },
+    ]);
+
+    if (confirmationMessage.useCommitMessage === "n") {
+      console.log(chalk.white("▲ ") + "Commit message has not been commited.");
+      process.exit(1);
+    }
+
+    execSync(`git commit -m "${aiCommitMessage}"`, {
+      stdio: "inherit",
+      encoding: "utf8",
+    });
+  } catch(error) {
+    console.error(error.message)
+  }  
 }
 
 async function generateCommitMessage(prompt: string) {
@@ -101,6 +107,10 @@ async function generateCommitMessage(prompt: string) {
     method: "POST",
     body: JSON.stringify(payload),
   });
+
+  if (!response.ok) {
+    throw new Error(`A problem has occured: ${response.status} ${response.statusText}`);
+  }  
 
   const json: any = await response.json();
   const aiCommit = json.choices[0].text;


### PR DESCRIPTION
Very naive error handling. The errors users are reporting maybe be because the key of course, but it seems also to be on OpenAI side