### PR TITLE
Rename environment variable for OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Install the CLI then grab your [OpenAI key](https://openai.com/api/) and add it as an env variable with the two commands below.
 
 1. `npm install -g aicommits`
-2. `export OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxx`
+2. `export OPENAI_KEY=sk-xxxxxxxxxxxxxxxx`
 
 It's recommended to add the line in #2 to your `.zshrc` or `.bashrc` so it persists instead of having to define it in each terminal session.
 
@@ -44,6 +44,7 @@ The next version of the CLI, version 2, will address both of these limitations a
 - Add support for conventional commits as a flag that users can enable
 - Add support for diffs greater than 200 lines by grabbing the diff per file
 - Add support for a flag that can auto-accept
-- Add opt-in emoji and languages flags
 - Add ability to specify a commit message from inside aicommit
+- Add opt-in emoji flag
+- Add opt-in languages flag
 - Build landing page for the 2.0 launch

--- a/aicommits.ts
+++ b/aicommits.ts
@@ -5,7 +5,7 @@ import { execSync } from "child_process";
 import inquirer from "inquirer";
 import fetch from "node-fetch";
 
-let OPENAI_KEY = process.env.OPENAI_KEY;
+let OPENAI_KEY = process.env.OPENAI_KEY ?? process.env.OPENAI_API_KEY;
 
 export async function main() {
   console.log(chalk.white("▲ ") + chalk.green("Welcome to AICommits!"));

--- a/aicommits.ts
+++ b/aicommits.ts
@@ -5,15 +5,15 @@ import { execSync } from "child_process";
 import inquirer from "inquirer";
 import fetch from "node-fetch";
 
-let OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+let OPENAI_KEY = process.env.OPENAI_KEY;
 
 export async function main() {
   console.log(chalk.white("▲ ") + chalk.green("Welcome to AICommits!"));
 
-  if (!OPENAI_API_KEY) {
+  if (!OPENAI_KEY) {
     console.error(
       chalk.white("▲ ") +
-        "Please save your OpenAI API key as an env variable by doing 'export OPENAI_API_KEY=YOUR_API_KEY'"
+        "Please save your OpenAI API key as an env variable by doing 'export OPENAI_KEY=YOUR_API_KEY'"
     );
     process.exit(1);
   }
@@ -28,7 +28,7 @@ export async function main() {
   }
 
   const diff = execSync(
-    "git diff --cached . ':(exclude)package-lock.json' ':(exclude)yarn.lock'",
+    `git diff --cached . ":(exclude)package-lock.json" ":(exclude)yarn.lock" ":(exclude)pnpm-lock.yaml"`,
     {
       encoding: "utf8",
     }
@@ -96,7 +96,7 @@ async function generateCommitMessage(prompt: string) {
   const response = await fetch("https://api.openai.com/v1/completions", {
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY ?? ""}`,
+      Authorization: `Bearer ${OPENAI_KEY ?? ""}`,
     },
     method: "POST",
     body: JSON.stringify(payload),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicommits",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Writes your git commit messages for you with AI",
   "files": [
     "bin"


### PR DESCRIPTION
This pull request updates the name of the environment variable for the OpenAI API key in the README file and source code. The new name is `OPENAI_KEY` and the previous name, `OPENAI_API_KEY`, is used as a fallback.

Addressing #1 