### PR TITLE
Add `git aic` subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "files": [
     "bin"
   ],
-  "bin": "bin/index.js",
+  "bin": {
+    "aicommits": "bin/index.js",
+    "git-aic": "bin/index.js"
+  },
   "repository": "https://github.com/Nutlope/aicommits",
   "author": "Hassan El Mghari (@nutlope)",
   "license": "MIT",


### PR DESCRIPTION
Besides executing `aicommits` to start the executable, a user can also use `git aic`. `aic` was chosen because `git aicommits` might be a bit too much to type. Since this is intended to be used with git repos, putting it under the `git ...` namespace made sense to me.

******

An alternative subcommand that I was thinking of would be `git commitai`, which would take advantage of the user's muscle-memory or shell completions using `git commit` -- just 2 extra keystrokes to decide to let AI write the commit. But `commitai` sounds like a completely different project than `aicommits` :shrug: `git aic` felt like something that would be easy to use and easy to remember.