### PR TITLE
Follow best practice while writing a commit.

### DIFF
--- a/aicommits.ts
+++ b/aicommits.ts
@@ -50,7 +50,7 @@ export async function main() {
     process.exit(1);
   }
 
-  let prompt = `I want you to act like a git commit message writer. I will input a git diff and your job is to convert it into a useful commit message. Do not preface the commit with anything, use the present tense, return a complete sentence, and do not repeat yourself: ${diff}`;
+  let prompt = `I want you to act like a git commit message writer. I will input a git diff and your job is to convert it into a useful commit message. Do not preface the commit with anything, use the present tense, return a complete sentence, commit message not longer than 50 characters, and do not repeat yourself: ${diff}`;
 
   console.log(
     chalk.white("▲ ") + chalk.gray("Generating your AI commit message...\n")


### PR DESCRIPTION
Update the prompt to follow the best practice in writing commit, Since it writes a very long commit which is not best practice. Commit should be no longer than 50 characters (50/72 Rule ) 