### PR TITLE
Add option to enable concise mode for short commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Install the CLI then grab your [OpenAI key](https://openai.com/api/) and add it as an env variable with the two commands below.
 
 1. `npm install -g aicommits`
-2. `export OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxx`
+2. `export OPENAI_KEY=sk-xxxxxxxxxxxxxxxx`
 
 It's recommended to add the line in #2 to your `.zshrc` or `.bashrc` so it persists instead of having to define it in each terminal session.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ It's recommended to add the line in #2 to your `.zshrc` or `.bashrc` so it persi
 
 After doing the two steps above, generate your commit by running `aicommits`.
 
+### Options
+
+- `-c | --concise`: Use concise output with short commit messages.
+
 > Note: If you get a EACCESS error on mac/linux when running the first command, try running it with `sudo npm install -g aicommits`.
 
 ## How it works

--- a/aicommits.ts
+++ b/aicommits.ts
@@ -5,15 +5,15 @@ import { execSync } from "child_process";
 import inquirer from "inquirer";
 import fetch from "node-fetch";
 
-let OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+let OPENAI_KEY = process.env.OPENAI_KEY;
 
 export async function main() {
   console.log(chalk.white("▲ ") + chalk.green("Welcome to AICommits!"));
 
-  if (!OPENAI_API_KEY) {
+  if (!OPENAI_KEY) {
     console.error(
       chalk.white("▲ ") +
-        "Please save your OpenAI API key as an env variable by doing 'export OPENAI_API_KEY=YOUR_API_KEY'"
+        "Please save your OpenAI API key as an env variable by doing 'export OPENAI_KEY=YOUR_API_KEY'"
     );
     process.exit(1);
   }
@@ -96,7 +96,7 @@ async function generateCommitMessage(prompt: string) {
   const response = await fetch("https://api.openai.com/v1/completions", {
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY ?? ""}`,
+      Authorization: `Bearer ${OPENAI_KEY ?? ""}`,
     },
     method: "POST",
     body: JSON.stringify(payload),

--- a/aicommits.ts
+++ b/aicommits.ts
@@ -6,6 +6,7 @@ import inquirer from "inquirer";
 import fetch from "node-fetch";
 
 let OPENAI_KEY = process.env.OPENAI_KEY ?? process.env.OPENAI_API_KEY;
+let isConcise = false;
 
 export async function main() {
   console.log(chalk.white("▲ ") + chalk.green("Welcome to AICommits!"));
@@ -50,10 +51,25 @@ export async function main() {
     process.exit(1);
   }
 
-  let prompt = `I want you to act like a git commit message writer. I will input a git diff and your job is to convert it into a useful commit message. Do not preface the commit with anything, use the present tense, return a complete sentence, and do not repeat yourself: ${diff}`;
+  const args = process.argv.slice(2);
+
+  args.forEach((arg) => {
+    if (arg === "--concise" || arg === "-c") {
+      isConcise = true;
+    }
+  });
+
+  let prompt = isConcise
+    ? `I want you to act like a git commit message writer. I will input a git diff and your job is to convert it into a useful, short, and concise commit message. Do not preface the commit with anything, use the present tense, return a complete sentence, and do not repeat yourself: ${diff}`
+    : `I want you to act like a git commit message writer. I will input a git diff and your job is to convert it into a useful commit message. Do not preface the commit with anything, use the present tense, return a complete sentence, and do not repeat yourself: ${diff}`;
 
   console.log(
-    chalk.white("▲ ") + chalk.gray("Generating your AI commit message...\n")
+    chalk.white("▲ ") +
+      chalk.white(
+        `Generating your AI commit message ${
+          isConcise ? "with consice mode on" : ""
+        } ...\n`
+      )
   );
 
   try {


### PR DESCRIPTION

This pull request adds a new option to enable concise mode for short commit messages. The `--concise` flag can be used to toggle the short commit messages. (#27)

When the `--concise` flag is used, additional keywords such as '**short**' and '**concise**' are included in the OpenAPI request payload to provide the necessary context for the AI to understand the user's intention better.

**This pull request includes the following changes:**

- Added a new option to enable concise mode
- Updated README.md file with instructions on how to use the new option

Please let me know if there are any issues with this pull request or any additional changes you would like me to make.

Thank you!