### PR TITLE
feat: read config from `~/.aicommits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the CLI then grab your [OpenAI key](https://openai.com/api/) and add it 
 1. `npm install -g aicommits`
 2. `export OPENAI_KEY=sk-xxxxxxxxxxxxxxxx`
 
-It's recommended to set the token a `.env` file at the root of your project, or your `.zshrc` or `.bashrc` so it persists instead of having to define it in each terminal session.
+It's recommended to set the token a [`.env` file](https://www.npmjs.com/package/dotenv) at the root of your project, or your `.zshrc` or `.bashrc` so it persists instead of having to define it in each terminal session.
 
 After doing the two steps above, generate your commit by running `aicommits`.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the CLI then grab your [OpenAI key](https://openai.com/api/) and add it 
 1. `npm install -g aicommits`
 2. `export OPENAI_KEY=sk-xxxxxxxxxxxxxxxx`
 
-It's recommended to add the line in #2 to your `.zshrc` or `.bashrc` so it persists instead of having to define it in each terminal session.
+It's recommended to set the token a `.env` file at the root of your project, or your `.zshrc` or `.bashrc` so it persists instead of having to define it in each terminal session.
 
 After doing the two steps above, generate your commit by running `aicommits`.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the CLI then grab your [OpenAI key](https://openai.com/api/) and add it 
 1. `npm install -g aicommits`
 2. `export OPENAI_KEY=sk-xxxxxxxxxxxxxxxx`
 
-It's recommended to set the token a [`.env` file](https://www.npmjs.com/package/dotenv) at the root of your project, or your `.zshrc` or `.bashrc` so it persists instead of having to define it in each terminal session.
+It's recommended to set the token in a [dotenv](https://www.npmjs.com/package/dotenv) file at `~/.aicommits` so it persists instead of having to define it in each terminal session.
 
 After doing the two steps above, generate your commit by running `aicommits`.
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	},
 	"devDependencies": {
 		"@pvtnbr/eslint-config": "^0.33.0",
+		"@types/dotenv": "^8.2.0",
 		"@types/node": "^18.13.0",
 		"eslint": "^8.34.0",
 		"typescript": "^4.9.5"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	},
 	"dependencies": {
 		"chalk": "^4.1.2",
+		"dotenv": "^16.0.3",
 		"inquirer": "^8.0.0",
 		"openai": "^3.1.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@pvtnbr/eslint-config': ^0.33.0
+  '@types/dotenv': ^8.2.0
   '@types/node': ^18.13.0
   chalk: ^4.1.2
   dotenv: ^16.0.3
@@ -18,6 +19,7 @@ dependencies:
 
 devDependencies:
   '@pvtnbr/eslint-config': 0.33.0_7kw3g6rralp5ps6mg3uyzz6azm
+  '@types/dotenv': 8.2.0
   '@types/node': 18.13.0
   eslint: 8.34.0
   typescript: 4.9.5
@@ -141,6 +143,13 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
       - typescript
+    dev: true
+
+  /@types/dotenv/8.2.0:
+    resolution: {integrity: sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==}
+    deprecated: This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.
+    dependencies:
+      dotenv: 16.0.3
     dev: true
 
   /@types/json-schema/7.0.11:
@@ -670,7 +679,6 @@ packages:
   /dotenv/16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
-    dev: false
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@pvtnbr/eslint-config': ^0.33.0
   '@types/node': ^18.13.0
   chalk: ^4.1.2
+  dotenv: ^16.0.3
   eslint: ^8.34.0
   inquirer: ^8.0.0
   openai: ^3.1.0
@@ -11,6 +12,7 @@ specifiers:
 
 dependencies:
   chalk: 4.1.2
+  dotenv: 16.0.3
   inquirer: 8.2.5
   openai: 3.1.0
 
@@ -664,6 +666,11 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
+
+  /dotenv/16.0.3:
+    resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import 'dotenv/config.js';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
 import inquirer from 'inquirer';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 
-import 'dotenv/config.js';
+import { config as dotenvConfig } from 'dotenv';
+import path from 'path';
+import os from 'os';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { Configuration, OpenAIApi } from 'openai';
+
+/**
+ * Read env vars from ~/.aicommits file for a secure but global way
+ * for users to store their OpenAI API key
+ */
+dotenvConfig({ path: path.join(os.homedir(), '.aicommits') });
 
 const OPENAI_KEY = process.env.OPENAI_KEY ?? process.env.OPENAI_API_KEY;
 


### PR DESCRIPTION
## Problem

`.env` files (usually at the project root) are a popular way to store project-specific environment variables.

Without them, devs may be copy-pasting them around insecurely, and may be in an arbitrary place that's easy to get lost.

Placing them in the shell config may also be insecure because it becomes accessible from any project or command. And different projects can potentially use the same variable names for different purposes.

Because this tool requires a sensitive private token, it should support reading from a file.

## Changes
- Use `dotenv` to read environment variables from `~/.aicommits` and populate `process.env` with it

