### PR TITLE
ci: add github actions for linting & type-checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2.2.2
+      with:
+        version: 7
+        run_install: true
+
+    - name: Type check
+      run: pnpm build
+
+    - name: Lint
+      run: pnpm lint


### PR DESCRIPTION
## Problem
When contributors open PRs, there are no basic checks that help with streamlining review.

## Changes
Add GitHub Actions to automatically check if the code builds and passes the linter.