### PR TITLE
build: strict mode, use esm, and target es2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"license": "MIT",
 	"repository": "https://github.com/Nutlope/aicommits",
 	"author": "Hassan El Mghari (@nutlope)",
+	"type": "module",
 	"files": [
 		"dist"
 	],
@@ -27,6 +28,7 @@
 	"devDependencies": {
 		"@pvtnbr/eslint-config": "^0.33.0",
 		"@types/ini": "^1.3.31",
+		"@types/inquirer": "^9.0.3",
 		"@types/node": "^18.13.0",
 		"eslint": "^8.34.0",
 		"typescript": "^4.9.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@pvtnbr/eslint-config': ^0.33.0
   '@types/ini': ^1.3.31
+  '@types/inquirer': ^9.0.3
   '@types/node': ^18.13.0
   chalk: ^4.1.2
   eslint: ^8.34.0
@@ -20,6 +21,7 @@ dependencies:
 devDependencies:
   '@pvtnbr/eslint-config': 0.33.0_7kw3g6rralp5ps6mg3uyzz6azm
   '@types/ini': 1.3.31
+  '@types/inquirer': 9.0.3
   '@types/node': 18.13.0
   eslint: 8.34.0
   typescript: 4.9.5
@@ -149,6 +151,13 @@ packages:
     resolution: {integrity: sha512-8ecxxaG4AlVEM1k9+BsziMw8UsX0qy3jYI1ad/71RrDZ+rdL6aZB0wLfAuflQiDhkD5o4yJ0uPK3OSUic3fG0w==}
     dev: true
 
+  /@types/inquirer/9.0.3:
+    resolution: {integrity: sha512-CzNkWqQftcmk2jaCWdBTf9Sm7xSw4rkI1zpU/Udw3HX5//adEZUIm9STtoRP1qgWj0CWQtJ9UTvqmO2NNjhMJw==}
+    dependencies:
+      '@types/through': 0.0.30
+      rxjs: 7.8.0
+    dev: true
+
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
@@ -173,6 +182,12 @@ packages:
 
   /@types/semver/7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
+
+  /@types/through/0.0.30:
+    resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
+    dependencies:
+      '@types/node': 18.13.0
     dev: true
 
   /@types/unist/2.0.6:
@@ -2355,7 +2370,6 @@ packages:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
       tslib: 2.5.0
-    dev: false
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import inquirer from 'inquirer';
 import {
 	getConfig,
 	generateCommitMessage,
-} from './utils';
+} from './utils.js';
 
 (async () => {
 	const config = await getConfig();
@@ -86,7 +86,7 @@ import {
 			encoding: 'utf8',
 		});
 	} catch (error) {
-		console.error(chalk.white('▲ ') + chalk.red(error.message));
+		console.error(chalk.white('▲ ') + chalk.red((error as any).message));
 		process.exit(1);
 	}
 })();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
 	"compilerOptions": {
-		"target": "es2016",
-		"module": "commonjs",
 		"outDir": "./dist",
+		"target": "ES2020",
+		"module": "Node16",
+		"strict": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
 		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */
+		"skipLibCheck": true
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
## Problem
- Code wasn't compiled in TypeScript Strict mode
	- Enabling strict mode required getting types for `inquirer`. But upon installing `@types/inquirer`, it complained that it's a module and can't be imported unless it's from a module
- The tsconfig target was set to `es2016`, which is [below Node 8](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) and very outdated

## Changes
- Enable Strict mode
	- Use `module` type package and update to Node 16 resolution 
- Up the target to `ES2020`, which is Node 14 (currently in LTS but [approaching end of life in April](https://github.com/nodejs/release#release-schedule))
