### PR TITLE
feat: show multiple options

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"dependencies": {
 		"@clack/prompts": "^0.2.2",
+		"cleye": "^1.3.2",
 		"execa": "^7.0.0",
 		"ini": "^3.0.1",
 		"kolorist": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@types/ini': ^1.3.31
   '@types/inquirer': ^9.0.3
   '@types/node': ^18.13.0
+  cleye: ^1.3.2
   eslint: ^8.34.0
   execa: ^7.0.0
   ini: ^3.0.1
@@ -16,6 +17,7 @@ specifiers:
 
 dependencies:
   '@clack/prompts': 0.2.2
+  cleye: 1.3.2
   execa: 7.0.0
   ini: 3.0.1
   kolorist: 1.7.0
@@ -853,6 +855,13 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
     dev: true
+
+  /cleye/1.3.2:
+    resolution: {integrity: sha512-MngIC2izcCz07iRKr3Pe8Z6ZBv4zbKFl/YnQEN/aMHis6PpH+MxI2e6n0bMUAmSVlMoAyQkdBCSTbfDmtcSovQ==}
+    dependencies:
+      terminal-columns: 1.4.1
+      type-flag: 3.0.0
+    dev: false
 
   /color-convert/1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -2900,6 +2909,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /terminal-columns/1.4.1:
+    resolution: {integrity: sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw==}
+    dev: false
+
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -2966,6 +2979,10 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
     dev: true
+
+  /type-flag/3.0.0:
+    resolution: {integrity: sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==}
+    dev: false
 
   /typed-array-length/1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}


### PR DESCRIPTION
## Changes
- Add a CLI interface, which supports `--help` and `--version` flags (e.g. `aicommmits --help` shows a manual on how to use the CLI tool)

- Adds a `generate` flag that accepts a number of messages to generate. (`alicommits --generate 3` for 3 messages) Aliased with `g` (e.g. `alicommits -g 3`).

	@Nutlope I had go pick a flag name that didn't collide with any [`git commit` flags](https://git-scm.com/docs/git-commit). Feel free to rename if you can think of a better one that doesn't overlap with git commit. 

<img width="419" src="https://user-images.githubusercontent.com/1075694/219393343-025e6371-95df-43e7-95d1-27dbc22e8d3d.png">


## Other information

Using `cleye` will set us up for transparently wrapping `git commit` so we can later pass down any unknown arguments (e.g. signing commits or even adding files `-a`).