### PR TITLE
feat: pass down argv to git commit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,11 @@ const argv = cli({
 
 	version,
 
+	/**
+	 * Since this is a wrapper around `git commit`,
+	 * flags should not overlap with it
+	 * https://git-scm.com/docs/git-commit
+	 */
 	flags: {
 		generate: {
 			type: Number,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,8 @@ import {
 	generateCommitMessage,
 } from './utils.js';
 
+const rawArgv = process.argv.slice(2);
+
 const argv = cli({
 	name: 'aicommits',
 
@@ -32,7 +34,9 @@ const argv = cli({
 	help: {
 		description,
 	},
-});
+
+	ignoreArgv: type => type === 'unknown-flag' || type === 'argument',
+}, undefined, rawArgv);
 
 (async () => {
 	intro(bgCyan(black(' aicommits ')));
@@ -91,7 +95,7 @@ const argv = cli({
 		message = selected;
 	}
 
-	await execa('git', ['commit', '-m', message]);
+	await execa('git', ['commit', '-m', message, ...rawArgv]);
 
 	outro(`${green('✔')} Successfully committed!`);
 })().catch((error) => {


### PR DESCRIPTION
## Previously
There were requests to support certain `git commit ` features (e.g. https://github.com/Nutlope/aicommits/issues/33).

closes https://github.com/Nutlope/aicommits/issues/33

## Currently

This passes down unused `argv` down to `git commit` so you can leverage most `git commit` features.

## Other info
- Support for `git commit -a` will be tricky, because it needs to add the files before aicommits runs
