### PR TITLE
update package.json version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aicommits",
-	"version": "1.0.7",
+	"version": "1.1.0",
 	"description": "Writes your git commit messages for you with AI",
 	"keywords": [
 		"ai",


### PR DESCRIPTION
When I use the latest version of `aicommits`, I use the command:

```bash
aicommits --version
# output
1.0.7
```
But the latest version of aicommits is 1.1.0
So please update the version of package.json