### PR TITLE
ci: setup semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2.2.2
+      with:
+        version: 7
+        run_install: true
+
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: pnpm dlx semantic-release

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"prepare": "simple-git-hooks",
 		"build": "pkgroll --minify",
 		"lint": "eslint --cache .",
-		"type-check": "tsc"
+		"type-check": "tsc",
+		"prepack": "pnpm build"
 	},
 	"simple-git-hooks": {
 		"pre-commit": "pnpm lint-staged"
@@ -46,5 +47,8 @@
 	},
 	"eslintConfig": {
 		"extends": "@pvtnbr"
+	},
+	"release": {
+		"branches": ["main"]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aicommits",
-	"version": "1.0.7",
+	"version": "0.0.0-semantic-release",
 	"description": "Writes your git commit messages for you with AI",
 	"keywords": [
 		"ai",


### PR DESCRIPTION
## Problem
- `package.json#version` not being bumped: https://github.com/Nutlope/aicommits/pull/88
- Releases can only be made by one person

## Changes

- Delegate releasing to GitHub Actions by running [`semantic-release`](https://github.com/semantic-release/semantic-release)

  This change makes it so that new commits merged to `main` will trigger semantic-release to make a release (if there's a fix/feat commit).

  Semantic Release works by looking at the new commits. It parses them based on their format (Angular Commit Message Conventions, which is basically Conventional Commits), and determines what kind of release to make (fix, feature, breaking). And makes a release to GitHub and npm with auto-generated release notes.

- Because releases are automated, there will be less points of failure and more reliable

- @Nutlope Before merging this in, please add your NPM token to the repo Action Secrets:

<img width="600"  src="https://user-images.githubusercontent.com/1075694/220123173-9a5781d3-1cbd-424e-89b1-f00caaf3b626.png">

## Other info

- This workflow where all commits to `main` are individually released is called [GitHub Flow](https://githubflow.github.io/). In contrast, there's [Git Flow](https://lucamezzalira.com/2014/03/10/git-flow-vs-github-flow/) which has a staging branch called `develop` so fixes/features can be released in batches. Personally, I use Git Flow in my projects because I like to have a staging environment and do some final testing before releases, but this is up to you.
  - If you would like to adopt Git Flow, please branch off `main` to create a `develop` branch, and set that to be the repository default branch.

- If you would like to be the one that triggers the releases on CI, please protect the main branch so it requires your review.