### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "features": {
         "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
     },
-    "postCreateCommand": "nvm i && pnpm i",
+    "postCreateCommand": "source $NVM_DIR/nvm.sh && nvm i && pnpm i",
     "postAttachCommand": "pnpm build -w",
     "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "Node.js",
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-16",
-    "postCreateCommand": "npm install",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node",
+    "features": {
+        "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
+    },
+    "postCreateCommand": "nvm i && pnpm i",
     "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,6 @@
         "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
     },
     "postCreateCommand": "nvm i && pnpm i",
+    "postAttachCommand": "pnpm build -w",
     "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "features": {
         "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
     },
-    "postCreateCommand": "source $NVM_DIR/nvm.sh && nvm i && pnpm i",
+    "postCreateCommand": ".devcontainer/postCreate.sh",
     "postAttachCommand": "pnpm build -w",
     "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "Node.js",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-16",
+    "postCreateCommand": "npm install",
+    "remoteUser": "node"
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+. $NVM_DIR/nvm.sh
+nvm i
+pnpm i


### PR DESCRIPTION
See #22 for previous discussion

This allows potential contributors to work in a GitHub Codespace with minimal setup on their end. They can start a codespace by clicking "Code" in the top-right of the repository's page, switching from the "Local" to the "Codespaces" tab, and then create a new codespace.

The contributors devcontainer will have Node, Typescript, and pnpm pre-installed. Once the container is created, `nvm` will install the appropriate Node version, and then `pnpm i` will be executed. Basically, the postCreateCommand will run the project setup in `CONTRIBUTING.md` for them.

Then, for the sake of convenience, the `postAttachCommand` will build the project in watch mode.

******

There are a few useless commits in this PR, so you'd probably want to squash-merge :laughing: