### PR TITLE
feat: exclude all *.lock files

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -11,6 +11,8 @@ export const assertGitRepo = async () => {
 const excludeFromDiff = [
 	'package-lock.json',
 	'pnpm-lock.yaml',
+
+	// yarn.lock, Cargo.lock, Gemfile.lock, Pipfile.lock, etc.
 	'*.lock',
 ].map(file => `:(exclude)${file}`);
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -10,8 +10,8 @@ export const assertGitRepo = async () => {
 
 const excludeFromDiff = [
 	'package-lock.json',
-	'yarn.lock',
 	'pnpm-lock.yaml',
+	'*.lock',
 ].map(file => `:(exclude)${file}`);
 
 export const getStagedDiff = async () => {


### PR DESCRIPTION
This registers more files to be excluded for these types of projects (specifically, their lock files):
- Python
- Ruby
- Rust