### PR TITLE
feat: Add option to prefix generated commit message

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,11 @@ cli(
 				alias: 'g',
 				default: 1,
 			},
+			prefix: {
+				type: String,
+				description: 'String to prefix to the generated commit message.',
+				default: '',
+			},
 		},
 
 		commands: [
@@ -44,6 +49,7 @@ cli(
 		} else {
 			aicommits(
 				argv.flags.generate,
+				argv.flags.prefix,
 				rawArgv,
 			);
 		}

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -15,6 +15,7 @@ import { generateCommitMessage } from '../utils/openai.js';
 
 export default async (
 	generate: number,
+	prefix: string,
 	rawArgv: string[],
 ) => (async () => {
 	intro(bgCyan(black(' aicommits ')));
@@ -51,6 +52,8 @@ export default async (
 	let message;
 	if (messages.length === 1) {
 		[message] = messages;
+		message = `${prefix} ${message}`;
+
 		const confirmed = await confirm({
 			message: `Use this commit message?\n\n   ${message}\n`,
 		});


### PR DESCRIPTION
This PR adds a flag `--prefix` to prefix a string to the generated commit message. It'll make it possible to use aicommits with many actual workflows while being very flexible and optional. 

Example 1: For this commit i used `aicommits --prefix feat:` to use conventional commits which is used in this repo. I agree with the discussion in #17 that it would be cool to get GPT to generate the conventional commit tag, however this would work in the short term and is flexible enough to cover other needs as well. Having a separate flag for generated semantic versions is still possible and does not conflict with this.

Example 2: For a monorepo project I work on we usually prefix our commits with the relevant project if they only touch one project or vertical. In that case I could use `aicommits --prefix web:` to indicate that a commit is for the web project. 

This resolves #111 and helps with #32, though still leaves room for work on that one.