### PR TITLE
feat: add maximum length flag (#91)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,23 +14,27 @@ cli(
 		version,
 
 		/**
-		 * Since this is a wrapper around `git commit`,
-		 * flags should not overlap with it
-		 * https://git-scm.com/docs/git-commit
-		 */
+     * Since this is a wrapper around `git commit`,
+     * flags should not overlap with it
+     * https://git-scm.com/docs/git-commit
+     */
 		flags: {
 			generate: {
 				type: Number,
-				description: 'Number of messages to generate. (Warning: generating multiple costs more)',
+				description:
+          'Number of messages to generate. (Warning: generating multiple costs more)',
 				alias: 'g',
 				default: 1,
 			},
+			length: {
+				type: Number,
+				description: 'Maximum length of the generated message',
+				alias: 'l',
+				default: 50,
+			},
 		},
 
-		commands: [
-			configCommand,
-			hookCommand,
-		],
+		commands: [configCommand, hookCommand],
 
 		help: {
 			description,
@@ -42,10 +46,7 @@ cli(
 		if (isCalledFromGitHook) {
 			prepareCommitMessageHook();
 		} else {
-			aicommits(
-				argv.flags.generate,
-				rawArgv,
-			);
+			aicommits(argv.flags.generate, rawArgv, argv.flags.length);
 		}
 	},
 	rawArgv,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,15 +14,14 @@ cli(
 		version,
 
 		/**
-     * Since this is a wrapper around `git commit`,
-     * flags should not overlap with it
-     * https://git-scm.com/docs/git-commit
-     */
+		 * Since this is a wrapper around `git commit`,
+		 * flags should not overlap with it
+		 * https://git-scm.com/docs/git-commit
+		 */
 		flags: {
 			generate: {
 				type: Number,
-				description:
-          'Number of messages to generate. (Warning: generating multiple costs more)',
+				description: 'Number of messages to generate. (Warning: generating multiple costs more)',
 				alias: 'g',
 				default: 1,
 			},
@@ -34,7 +33,10 @@ cli(
 			},
 		},
 
-		commands: [configCommand, hookCommand],
+		commands: [
+			configCommand,
+			hookCommand,
+		],
 
 		help: {
 			description,
@@ -46,7 +48,11 @@ cli(
 		if (isCalledFromGitHook) {
 			prepareCommitMessageHook();
 		} else {
-			aicommits(argv.flags.generate, rawArgv, argv.flags.length);
+			aicommits(
+				argv.flags.generate,
+				rawArgv,
+				argv.flags.length,
+			);
 		}
 	},
 	rawArgv,

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -16,6 +16,7 @@ import { generateCommitMessage } from '../utils/openai.js';
 export default async (
 	generate: number,
 	rawArgv: string[],
+	maximumLength: number,
 ) => (async () => {
 	intro(bgCyan(black(' aicommits ')));
 
@@ -45,6 +46,7 @@ export default async (
 		OPENAI_KEY,
 		staged.diff,
 		generate,
+		maximumLength,
 	);
 	s.stop('Changes analyzed');
 

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -4,14 +4,15 @@ const sanitizeMessage = (message: string) => message.trim().replace(/[\n\r]/g, '
 
 const deduplicateMessages = (array: string[]) => Array.from(new Set(array));
 
-const promptTemplate = 'Write an insightful but concise Git commit message in a complete sentence in present tense for the following diff without prefacing it with anything:';
+const promptTemplate = 'Write an insightful but concise Git commit message in a complete sentence in present tense for the following diff without prefacing it with anything, making sure it is exactly or less than [count] characters long:';
 
 export const generateCommitMessage = async (
 	apiKey: string,
 	diff: string,
 	completions: number,
+	maximumLength: number,
 ) => {
-	const prompt = `${promptTemplate}\n${diff}`;
+	const prompt = `${promptTemplate.replace('[count]', maximumLength.toString())}\n${diff}`;
 
 	// Accounting for GPT-3's input req of 4k tokens (approx 8k chars)
 	if (prompt.length > 8000) {


### PR DESCRIPTION
adding the length flag in reference to #91. 

i assumed the default value of the maximum length according to [the 50/72 rule](https://www.midori-global.com/blog/2018/04/02/git-50-72-rule), but of course this is still an opinionated change and should be discussed according to what you guys think!

---

i still have an issue though with `commands/prepare-commits-msg-hook.ts`, should it:
1. pass the length as an argument from `cli.ts` to `generateCommitMessage`,
2. hardcode the length inside the `generateCommitMessage` invocation,
3. make the length argument optional with a default value of 50 (or something else)
4. something better around the `process.argv.slice line`? (probably bad for maintainability)

thx for reading!