### PR TITLE
fix: restore cursor visibility in case of errors

### DIFF
--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -42,7 +42,7 @@ export default async (
 
 	const s = spinner();
 	s.start('The AI is analyzing your changes');
-	let messages;
+	let messages: string[];
 	try {
 		messages = await generateCommitMessage(
 			config.OPENAI_KEY,
@@ -50,11 +50,9 @@ export default async (
 			staged.diff,
 			config.generate,
 		);
-	} catch (error) {
-		s.stop('The AI is analyzing your changes');
-		throw error;
+	} finally {
+		s.stop('Changes analyzed');
 	}
-	s.stop('Changes analyzed');
 
 	if (messages.length === 0) {
 		throw new KnownError('No commit messages were generated. Try again.');

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -34,12 +34,18 @@ export default () => (async () => {
 
 	const s = spinner();
 	s.start('The AI is analyzing your changes');
-	const messages = await generateCommitMessage(
-		config.OPENAI_KEY,
-		config.locale,
-		staged!.diff,
-		config.generate,
-	);
+	let messages;
+	try {
+		messages = await generateCommitMessage(
+			config.OPENAI_KEY,
+			config.locale,
+			staged!.diff,
+			config.generate,
+		);
+	} catch (error) {
+		s.stop('The AI is analyzing your changes');
+		throw error;
+	}
 	s.stop('Changes analyzed');
 
 	const hasMultipleMessages = messages.length > 1;

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -34,7 +34,7 @@ export default () => (async () => {
 
 	const s = spinner();
 	s.start('The AI is analyzing your changes');
-	let messages;
+	let messages: string[];
 	try {
 		messages = await generateCommitMessage(
 			config.OPENAI_KEY,
@@ -42,12 +42,9 @@ export default () => (async () => {
 			staged!.diff,
 			config.generate,
 		);
-	} catch (error) {
-		s.stop('The AI is analyzing your changes');
-		throw error;
+	} finally {
+		s.stop('Changes analyzed');
 	}
-	s.stop('Changes analyzed');
-
 	const hasMultipleMessages = messages.length > 1;
 	let instructions = `# 🤖 AI generated commit${hasMultipleMessages ? 's' : ''}\n`;
 


### PR DESCRIPTION
The `spinner.start` function from `clack@promts` package hides terminal cursor, in case of errors the cursor remains hidden. To fix this, I've added a call to `spinner.stop()` before throwing errors. This will unhide the cursor,