### PR TITLE
docs: `--generate` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ aicommits --dry-run
 
 #### Generate multiple recommendations
 
-Sometimes the recommended commit message isn't the best so you want it to generate a few to pick from. You can generate multiple commit messages at once by passing in the `--generate` flag:
+Sometimes the recommended commit message isn't the best so you want it to generate a few to pick from. You can generate multiple commit messages at once by passing in the `--generate <i>` flag, where 'i' is the number of generated messages:
 ```sh
-aicommits --generate # or -g
+aicommits --generate <i> # or -g <i>
 ```
 
 > Warning: this uses more tokens, meaning it costs more.


### PR DESCRIPTION
I ran into a small issue while following the README word by word. The flag to generate some messages needs an argument. This was not clear to me. I hope my change is helpful so that other don't experience the same.