### PR TITLE
fix: `git diff` to respect excluded files

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -44,6 +44,11 @@ export const getStagedDiff = async (excludeFiles?: string[]) => {
 		[
 			...diffCached,
 			...filesToExclude,
+			...(
+				excludeFiles
+					? excludeFiles.map(excludeFromDiff)
+					: []
+			),
 		],
 	);
 


### PR DESCRIPTION
Exclude files only exclude from display files but 'diff' still take all files