### PR TITLE
refactor: improve commit length enforcement

### DIFF
--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -109,10 +109,10 @@ const getPrompt = (
 	diff: string,
 	maxLength: number,
 ) => `${[
-	'Generate a concise git commit message written in present tense for the following code diff with the given specifications.',
+	'Generate a concise git commit message written in present tense for the following code diff with the given specifications below:',
 	`Message language: ${locale}`,
-	`Max message character length: ${maxLength}`,
-	'Exclude anything unnecessary such as the original translation—your entire response will be passed directly into git commit.',
+	`Commit message must be a maximum of ${maxLength} characters.`,
+	'Exclude anything unnecessary such as translation. Your entire response will be passed directly into git commit.',
 ].join('\n')}\n\n${diff}`;
 
 const generateStringFromLength = (length: number) => {

--- a/tests/specs/cli/commits.ts
+++ b/tests/specs/cli/commits.ts
@@ -55,7 +55,7 @@ export default testSuite(({ describe }) => {
 				commitMessage,
 				length: commitMessage.length,
 			});
-			expect(commitMessage.length <= 50).toBe(true);
+			expect(commitMessage.length).toBeLessThanOrEqual(50);
 
 			await fixture.rm();
 		});
@@ -122,7 +122,7 @@ export default testSuite(({ describe }) => {
 				commitMessage,
 				length: commitMessage.length,
 			});
-			expect(commitMessage.length <= 50).toBe(true);
+			expect(commitMessage.length).toBeLessThanOrEqual(50);
 
 			await fixture.rm();
 		});
@@ -165,7 +165,7 @@ export default testSuite(({ describe }) => {
 				commitMessage,
 				length: commitMessage.length,
 			});
-			expect(commitMessage.length <= 50).toBe(true);
+			expect(commitMessage.length).toBeLessThanOrEqual(50);
 
 			await fixture.rm();
 		});
@@ -203,7 +203,7 @@ export default testSuite(({ describe }) => {
 				length: commitMessage.length,
 			});
 			expect(commitMessage).toMatch(japanesePattern);
-			expect(commitMessage.length <= 50).toBe(true);
+			expect(commitMessage.length).toBeLessThanOrEqual(50);
 
 			await fixture.rm();
 		});
@@ -267,7 +267,7 @@ export default testSuite(({ describe }) => {
 					commitMessage,
 					length: commitMessage.length,
 				});
-				expect(commitMessage.length <= 50).toBe(true);
+				expect(commitMessage.length).toBeLessThanOrEqual(50);
 
 				await fixture.rm();
 			});
@@ -302,7 +302,7 @@ export default testSuite(({ describe }) => {
 					commitMessage,
 					length: commitMessage.length,
 				});
-				expect(commitMessage.length <= 50).toBe(true);
+				expect(commitMessage.length).toBeLessThanOrEqual(50);
 
 				await fixture.rm();
 			});


### PR DESCRIPTION
Extracted changes from https://github.com/Nutlope/aicommits/pull/177