### PR TITLE
Add note about reading OPENAI_KEY and OPENAI_API_KEY variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
     This will create a `.aicommits` file in your home directory.
 
+    *Note:* `aicommits` CLI will also automatically [read your OPENAI_KEY and OPENAI_API_KEY](./src/commands/aicommits.ts:47) env vars so be sure to check those in case you have problems.
+
 
 ### Upgrading
 


### PR DESCRIPTION
Today I've spent good 30 min trying to figure out why my configured `OPENAI_KEY` from `~/.aicommits` was not being used. It turned out env vars `OPENAI_KEY` and `OPENAI_API_KEY` take priority over config file. This is second time this happened to me, and each time I had to go and read the code.

While this behaviour is more or less fine, I'd like to add this note to README explaining this behaviour to users.