### PR TITLE
docs: `type` flag/config for Conventional Commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ aicommits --generate <i> # or -g <i>
 
 > Warning: this uses more tokens, meaning it costs more.
 
+#### Generating Conventional Commits
+
+If you'd like to generate [Conventional Commits](https://conventionalcommits.org/), you can use the `--type` flag followed by `conventional`. This will prompt `aicommits` to format the commit message according to the Conventional Commits specification:
+
+```sh
+aicommits --type conventional # or -t conventional
+```
+
+This feature can be useful if your project follows the Conventional Commits standard or if you're using tools that rely on this commit format.
+
 ### Git hook
 
 You can also integrate _aicommits_ with Git via the [`prepare-commit-msg`](https://git-scm.com/docs/githooks#_prepare_commit_msg) hook. This lets you use Git like you normally would, and edit the commit message before committing.
@@ -201,6 +211,22 @@ Default: `50`
 
 ```sh
 aicommits config set max-length=100
+```
+
+#### type
+
+Default: `""` (Empty string)
+
+The type of commit message to generate. Set this to "conventional" to generate commit messages that follow the Conventional Commits specification:
+
+```sh
+aicommits config set type=conventional
+```
+
+You can clear this option by setting it to an empty string:
+
+```sh
+aicommits config set type=
 ```
 
 ## How it works


### PR DESCRIPTION
This update to the README explains the new `type` configuration option, how to set it to "conventional" to generate Conventional Commits, and how to clear this option.

close #213 