### PR TITLE
Add tip to set the key using a password manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@
     ```
 
     This will create a `.aicommits` file in your home directory.
+    > **Tip**: You might want to set your key using a password manager.
+    ```sh
+    export OPENAI_KEY=$(<your command to get the key>)
+    ```
 
 
 ### Upgrading


### PR DESCRIPTION
I think it's a good idea add a tip on the README to set the key through a password manager for all my security-caring friends.
I commented about this on this #227 issue.