### PR TITLE
Enable support for auto-confirm commit messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # macOS
 .DS_Store
 
+# IDE
+.idea
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -229,6 +229,16 @@ You can clear this option by setting it to an empty string:
 aicommits config set type=
 ```
 
+#### auto-confirm
+
+Default: `false`
+
+Automatically confirm the generated commit message without prompting the user.
+
+```sh
+aicommits config set auto-confirm=true
+```
+
 ## How it works
 
 This CLI tool runs `git diff` to grab all your latest code changes, sends them to OpenAI's GPT-3, then returns the AI generated commit message.

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -77,9 +77,9 @@ export default async (
 	if (messages.length === 1) {
 		[message] = messages;
 
-		let confirmed: boolean
+		let confirmed: boolean | symbol;
 		if (config['auto-confirm']) {
-			confirmed = true
+			confirmed = true;
 		} else {
 			confirmed = await confirm({
 				message: `Use this commit message?\n\n   ${message}\n`,

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -76,9 +76,15 @@ export default async (
 	let message: string;
 	if (messages.length === 1) {
 		[message] = messages;
-		const confirmed = await confirm({
-			message: `Use this commit message?\n\n   ${message}\n`,
-		});
+
+		let confirmed: boolean
+		if (config['auto-confirm']) {
+			confirmed = true
+		} else {
+			confirmed = await confirm({
+				message: `Use this commit message?\n\n   ${message}\n`,
+			});
+		}
 
 		if (!confirmed || isCancel(confirmed)) {
 			outro('Commit cancelled');

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -104,15 +104,18 @@ const configParsers = {
 
 		return parsed;
 	},
-	'auto-confirm'(autoConfirm?: string) {
+	'auto-confirm'(autoConfirm?: string|boolean) {
 		if (!autoConfirm) {
 			return false;
 		}
 
-		parseAssert('auto-confirm', /^(true|false)$/.test(autoConfirm), 'Must be a boolean');
+		if (typeof autoConfirm === 'boolean') {
+			return autoConfirm;
+		}
 
+		parseAssert('auto-confirm', /^(?:true|false)$/.test(autoConfirm), 'Must be a boolean');
 		return autoConfirm === 'true';
-	}
+	},
 } as const;
 
 type ConfigKeys = keyof typeof configParsers;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -104,6 +104,15 @@ const configParsers = {
 
 		return parsed;
 	},
+	'auto-confirm'(autoConfirm?: string) {
+		if (!autoConfirm) {
+			return false;
+		}
+
+		parseAssert('auto-confirm', /^(true|false)$/.test(autoConfirm), 'Must be a boolean');
+
+		return autoConfirm === 'true';
+	}
 } as const;
 
 type ConfigKeys = keyof typeof configParsers;

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -101,6 +101,30 @@ export default testSuite(({ describe }) => {
 			});
 		});
 
+		await describe('auto-confirm', ({ test }) => {
+			test('must be a boolean', async () => {
+				const { stderr } = await aicommits(['config', 'set', 'auto-confirm=abc'], {
+					reject: false,
+				});
+
+				expect(stderr).toMatch('Must be a boolean');
+			});
+
+			test('updates config', async () => {
+				const defaultConfig = await aicommits(['config', 'get', 'auto-confirm']);
+				expect(defaultConfig.stdout).toBe('auto-confirm=false');
+
+				const autoConfirm = 'auto-confirm=true';
+				await aicommits(['config', 'set', autoConfirm]);
+
+				const configFile = await fs.readFile(configPath, 'utf8');
+				expect(configFile).toMatch(autoConfirm);
+
+				const get = await aicommits(['config', 'get', 'auto-confirm']);
+				expect(get.stdout).toBe(autoConfirm);
+			});
+		});
+
 		await test('set config file', async () => {
 			await aicommits(['config', 'set', openAiToken]);
 


### PR DESCRIPTION
Add a configuration option to automatically confirm commit messages.

This also references this issue: https://github.com/Nutlope/aicommits/issues/216

**Usage**

```sh
aicommits config set auto-confirm=true
```