### PR TITLE
feat: add `--locale` cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ aicommits --all # or -a
 
 > 👉 **Tip:** Use the `aic` alias if `aicommits` is too long for you.
 
+#### Generate with a specific locale
+
+You can generate a commit message with a specific locale by passing in the `--locale <locale>` flag, where 'locale' is the locale code:
+```sh
+aicommits --locale <locale> # or -l <locale>
+```
+
+Consult the list of codes in: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes.
+
 #### Generate multiple recommendations
 
 Sometimes the recommended commit message isn't the best so you want it to generate a few to pick from. You can generate multiple commit messages at once by passing in the `--generate <i>` flag, where 'i' is the number of generated messages:
@@ -166,7 +175,7 @@ The OpenAI API key. You can retrieve it from [OpenAI API Keys page](https://plat
 #### locale
 Default: `en`
 
-The locale to use for the generated commit messages. Consult the list of codes in: https://wikipedia.org/wiki/List_of_ISO_639-1_codes.
+The locale to use for the generated commit messages. Consult the list of codes in: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes.
 
 #### generate
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,11 @@ cli(
 		 * https://git-scm.com/docs/git-commit
 		 */
 		flags: {
+			locale: {
+				type: String,
+				description: 'Locale to use for the generated commit messages (default: en)',
+				alias: 'l',
+			},
 			generate: {
 				type: Number,
 				description: 'Number of messages to generate (Warning: generating multiple costs more) (default: 1)',
@@ -58,6 +63,7 @@ cli(
 			prepareCommitMessageHook();
 		} else {
 			aicommits(
+				argv.flags.locale,
 				argv.flags.generate,
 				argv.flags.exclude,
 				argv.flags.all,

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -15,6 +15,7 @@ import { generateCommitMessage } from '../utils/openai.js';
 import { KnownError, handleCliError } from '../utils/error.js';
 
 export default async (
+	locale: string | undefined,
 	generate: number | undefined,
 	excludeFiles: string[],
 	stageAll: boolean,
@@ -46,6 +47,7 @@ export default async (
 	const config = await getConfig({
 		OPENAI_KEY: env.OPENAI_KEY || env.OPENAI_API_KEY,
 		proxy: env.https_proxy || env.HTTPS_PROXY || env.http_proxy || env.HTTP_PROXY,
+		locale: locale?.toString(),
 		generate: generate?.toString(),
 		type: commitType?.toString(),
 	});


### PR DESCRIPTION
This PR allows us to dynamically specify a locale with the `--locale` CLI flag.

![image](https://github.com/Nutlope/aicommits/assets/4360663/9f53a67f-dee0-4042-ae9b-78cb5ad5d871)

![image](https://github.com/Nutlope/aicommits/assets/4360663/1ae0eb84-4eab-4564-9f44-22d56c6f4709)
