### PR TITLE
Hook fixes

### DIFF
--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -87,7 +87,10 @@ export default () =>
 			instructions += `\n${messages[0]}\n`;
 		}
 
-		await fs.appendFile(messageFilePath, instructions);
+		const currentContent = await fs.readFile(messageFilePath, 'utf8');
+		const newContent = instructions + '\n' + currentContent;
+		await fs.writeFile(messageFilePath, newContent);
+
 		outro(`${green('✔')} Saved commit message!`);
 	})().catch((error) => {
 		outro(`${red('✖')} ${error.message}`);

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -75,7 +75,7 @@ export default () =>
 		if (hasMultipleMessages) {
 			if (supportsComments) {
 				instructions +=
-					'# Select one of the following messages by uncommeting:\n';
+					'# Select one of the following messages by uncommenting:\n';
 			}
 			instructions += `\n${messages
 				.map((message) => `# ${message}`)


### PR DESCRIPTION
1. Fixes a spelling mistake
2. The instructions should be prepended, not appended.

With --verbose, the file contains

```
# ------------------------ >8 ------------------------
# Do not modify or remove the line above.
# Everything below it will be ignored.
```

Fix courtesy of https://chat.openai.com/share/a7452aa6-aefd-4284-adeb-37e3491b07ff ;)
