### PR TITLE
Set path, hostname, auth

### DIFF
--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -73,6 +73,7 @@ export default async (
 				config['max-length'],
 				config.type,
 				config.timeout,
+				config.authHeaderName,
 				config.hostname,
 				config.path,
 				config.proxy

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -69,7 +69,6 @@ export default async (
 			false
 		);
 
-
 		const s = spinner();
 		s.start('The AI is analyzing your changes');
 		let messages: string[];

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -52,19 +52,30 @@ export default async (
 		);
 
 		const { env } = process;
-		const config = await getConfig({
-			OPENAI_KEY: env.OPENAI_KEY || env.OPENAI_API_KEY,
-			proxy:
-				env.https_proxy || env.HTTPS_PROXY || env.http_proxy || env.HTTP_PROXY,
-			generate: generate?.toString(),
-			type: commitType?.toString(),
-		});
+		const config = await getConfig(
+			{
+				OPENAI_KEY: env.OPENAI_KEY || env.OPENAI_API_KEY,
+				authHeaderName: env.authHeaderName,
+				hostname: env.hostname,
+				apipath: env.apipath,
+				proxy:
+					env.https_proxy ||
+					env.HTTPS_PROXY ||
+					env.http_proxy ||
+					env.HTTP_PROXY,
+				generate: generate?.toString(),
+				type: commitType?.toString(),
+			},
+			false
+		);
+
 
 		const s = spinner();
 		s.start('The AI is analyzing your changes');
 		let messages: string[];
 		try {
 			messages = await generateCommitMessage(
+				config.authHeaderName,
 				config.OPENAI_KEY,
 				config.model,
 				config.locale,
@@ -73,9 +84,8 @@ export default async (
 				config['max-length'],
 				config.type,
 				config.timeout,
-				config.authHeaderName,
 				config.hostname,
-				config.path,
+				config.apipath,
 				config.proxy
 			);
 		} finally {

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -73,6 +73,8 @@ export default async (
 				config['max-length'],
 				config.type,
 				config.timeout,
+				config.hostname,
+				config.path,
 				config.proxy
 			);
 		} finally {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -25,7 +25,10 @@ export default command(
 
 			if (mode === 'set') {
 				await setConfigs(
-					keyValues.map((keyValue) => keyValue.split('=') as [string, string])
+					keyValues.map((keyValue) => {
+						const equals = keyValue.indexOf('=')
+						return [keyValue.substring(0,equals), keyValue.substring(equals+1)]
+					})
 				);
 				return;
 			}

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -40,6 +40,7 @@ export default () =>
 		let messages: string[];
 		try {
 			messages = await generateCommitMessage(
+				config.authHeaderName,
 				config.OPENAI_KEY,
 				config.model,
 				config.locale,
@@ -49,7 +50,7 @@ export default () =>
 				config.type,
 				config.timeout,
 				config.hostname,
-				config.path,
+				config.apipath,
 				config.proxy
 			);
 		} finally {

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -48,6 +48,8 @@ export default () =>
 				config['max-length'],
 				config.type,
 				config.timeout,
+				config.hostname,
+				config.path,
 				config.proxy
 			);
 		} finally {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -113,19 +113,32 @@ const configParsers = {
 
 		return parsed;
 	},
+	authHeaderName(authHeaderName?: string) {
+		if (!authHeaderName) {
+			return 'Authorization';
+		}
+
+		return authHeaderName;
+	},
 	hostname(hostname?: string) {
 		if (!hostname) {
 			return 'api.openai.com';
 		}
 
+		parseAssert(
+			'hostname',
+			!/^http/i.test(hostname) && !/\/$/.test(hostname),
+			'Do not include protocol or path in hostname, only hostname'
+		);
+
 		return hostname;
 	},
-	path(path?: string) {
-		if (!path) {
+	apipath(apipath?: string) {
+		if (!apipath) {
 			return '/v1/chat/completions';
 		}
 
-		return path;
+		return apipath;
 	},
 } as const;
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,8 +27,6 @@ const configParsers = {
 				'Please set your OpenAI API key via `aicommits config set OPENAI_KEY=<your token>`'
 			);
 		}
-		parseAssert('OPENAI_KEY', key.startsWith('sk-'), 'Must start with "sk-"');
-		// Key can range from 43~51 characters. There's no spec to assert this.
 
 		return key;
 	},
@@ -114,6 +112,20 @@ const configParsers = {
 		);
 
 		return parsed;
+	},
+	hostname(hostname?: string) {
+		if (!hostname) {
+			return 'api.openai.com';
+		}
+
+		return hostname;
+	},
+	path(path?: string) {
+		if (!path) {
+			return '/v1/chat/completions';
+		}
+
+		return path;
 	},
 } as const;
 

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -71,13 +71,26 @@ const createChatCompletion = async (
 	apiKey: string,
 	json: CreateChatCompletionRequest,
 	timeout: number,
+	hostname: string,
+	path: string,
 	proxy?: string
 ) => {
+
+	console.log({
+		hostname:hostname,
+		path:path,
+		headers:{
+			"api-key": `${apiKey}`,
+		},
+		json:json,
+		timeout:timeout,
+		proxy:proxy});
+
 	const { response, data } = await httpsPost(
-		'api.openai.com',
-		'/v1/chat/completions',
+		hostname,
+		path,
 		{
-			Authorization: `Bearer ${apiKey}`,
+			"api-key": `${apiKey}`,
 		},
 		json,
 		timeout,
@@ -139,6 +152,8 @@ export const generateCommitMessage = async (
 	maxLength: number,
 	type: CommitType,
 	timeout: number,
+	hostname: string,
+	path: string,
 	proxy?: string
 ) => {
 	try {
@@ -165,6 +180,8 @@ export const generateCommitMessage = async (
 				n: completions,
 			},
 			timeout,
+			hostname,
+			path,
 			proxy
 		);
 

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -79,7 +79,6 @@ const createChatCompletion = async (
 	let headers: any = {};
 	headers[authHeaderName] = `${apiKey}`;
 
-
 	const { response, data } = await httpsPost(
 		hostname,
 		apipath,

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -15,7 +15,7 @@ import { generatePrompt } from './prompt.js';
 
 const httpsPost = async (
 	hostname: string,
-	path: string,
+	apipath: string,
 	headers: Record<string, string>,
 	json: unknown,
 	timeout: number,
@@ -31,7 +31,7 @@ const httpsPost = async (
 			{
 				port: 443,
 				hostname,
-				path,
+				path: apipath,
 				method: 'POST',
 				headers: {
 					...headers,
@@ -68,30 +68,22 @@ const httpsPost = async (
 	});
 
 const createChatCompletion = async (
+	authHeaderName: string,
 	apiKey: string,
 	json: CreateChatCompletionRequest,
 	timeout: number,
 	hostname: string,
-	path: string,
+	apipath: string,
 	proxy?: string
 ) => {
+	let headers: any = {};
+	headers[authHeaderName] = `${apiKey}`;
 
-	console.log({
-		hostname:hostname,
-		path:path,
-		headers:{
-			"api-key": `${apiKey}`,
-		},
-		json:json,
-		timeout:timeout,
-		proxy:proxy});
 
 	const { response, data } = await httpsPost(
 		hostname,
-		path,
-		{
-			"api-key": `${apiKey}`,
-		},
+		apipath,
+		headers,
 		json,
 		timeout,
 		proxy
@@ -144,6 +136,7 @@ const deduplicateMessages = (array: string[]) => Array.from(new Set(array));
 // };
 
 export const generateCommitMessage = async (
+	authHeaderName: string,
 	apiKey: string,
 	model: TiktokenModel,
 	locale: string,
@@ -153,11 +146,12 @@ export const generateCommitMessage = async (
 	type: CommitType,
 	timeout: number,
 	hostname: string,
-	path: string,
+	apipath: string,
 	proxy?: string
 ) => {
 	try {
 		const completion = await createChatCompletion(
+			authHeaderName,
 			apiKey,
 			{
 				model,
@@ -181,7 +175,7 @@ export const generateCommitMessage = async (
 			},
 			timeout,
 			hostname,
-			path,
+			apipath,
 			proxy
 		);
 

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -97,15 +97,17 @@ export default testSuite(({ describe }) => {
 		});
 
 		await describe('hostname', ({ test }) => {
-			test('must be an hostname', async () => {
+			test('must be a hostname', async () => {
 				const { stderr } = await aicommits(
-					['config', 'set', 'hostname=https://api.openai.com'],
+					['config', 'set', 'hostname=https://api.openai.com/'],
 					{
 						reject: false,
 					}
 				);
 
-				expect(stderr).toMatch('Must be an hostname');
+				expect(stderr).toMatch(
+					'Do not include protocol or path in hostname, only hostname'
+				);
 			});
 
 			test('updates config', async () => {

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -17,16 +17,6 @@ export default testSuite(({ describe }) => {
 			expect(stderr).toMatch('Invalid config property: UNKNOWN');
 		});
 
-		test('set invalid OPENAI_KEY', async () => {
-			const { stderr } = await aicommits(['config', 'set', 'OPENAI_KEY=abc'], {
-				reject: false,
-			});
-
-			expect(stderr).toMatch(
-				'Invalid config property OPENAI_KEY: Must start with "sk-"'
-			);
-		});
-
 		await test('set config file', async () => {
 			await aicommits(['config', 'set', openAiToken]);
 
@@ -103,6 +93,33 @@ export default testSuite(({ describe }) => {
 
 				const get = await aicommits(['config', 'get', 'max-length']);
 				expect(get.stdout).toBe(maxLength);
+			});
+		});
+
+		await describe('hostname', ({ test }) => {
+			test('must be an hostname', async () => {
+				const { stderr } = await aicommits(
+					['config', 'set', 'hostname=https://api.openai.com'],
+					{
+						reject: false,
+					}
+				);
+
+				expect(stderr).toMatch('Must be an hostname');
+			});
+
+			test('updates config', async () => {
+				const defaultConfig = await aicommits(['config', 'get', 'hostname']);
+				expect(defaultConfig.stdout).toBe('hostname=api.openai.com');
+
+				const hostname = 'hostname=api.chatanywhere.com.cn';
+				await aicommits(['config', 'set', hostname]);
+
+				const configFile = await fs.readFile(configPath, 'utf8');
+				expect(configFile).toMatch(hostname);
+
+				const get = await aicommits(['config', 'get', 'hostname']);
+				expect(get.stdout).toBe(hostname);
 			});
 		});
 

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -100,9 +100,7 @@ export default testSuite(({ describe }) => {
 			test('must be a hostname', async () => {
 				const { stderr } = await aicommits(
 					['config', 'set', 'hostname=https://api.openai.com/'],
-					{
-						reject: false,
-					}
+					{ reject: false }
 				);
 
 				expect(stderr).toMatch(

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -97,7 +97,7 @@ export default testSuite(({ describe }) => {
 		});
 
 		await describe('hostname', ({ test }) => {
-			test('must be a hostname', async () => {
+			test('must be an hostname', async () => {
 				const { stderr } = await aicommits(
 					['config', 'set', 'hostname=https://api.openai.com/'],
 					{ reject: false }

--- a/tests/specs/openai/conventional-commits.ts
+++ b/tests/specs/openai/conventional-commits.ts
@@ -146,7 +146,8 @@ export default testSuite(({ describe }) => {
 				config.generate,
 				config['max-length'],
 				config.type,
-				7000
+				7000,
+				config.hostname
 			);
 
 			return commitMessages[0];

--- a/tests/specs/openai/conventional-commits.ts
+++ b/tests/specs/openai/conventional-commits.ts
@@ -3,7 +3,7 @@ import { generateCommitMessage } from '../../../src/utils/openai.js';
 import type { ValidConfig } from '../../../src/utils/config.js';
 import { getDiff } from '../../utils.js';
 
-const { OPENAI_KEY } = process.env;
+const { OPENAI_KEY, authHeaderName, hostname, apipath } = process.env;
 
 export default testSuite(({ describe }) => {
 	if (!OPENAI_KEY) {
@@ -139,6 +139,7 @@ export default testSuite(({ describe }) => {
 				...configOverrides,
 			} as ValidConfig;
 			const commitMessages = await generateCommitMessage(
+				authHeaderName ?? 'Authorization',
 				OPENAI_KEY!,
 				'gpt-3.5-turbo',
 				config.locale,
@@ -147,7 +148,8 @@ export default testSuite(({ describe }) => {
 				config['max-length'],
 				config.type,
 				7000,
-				config.hostname
+				hostname ?? 'api.openai.com',
+				apipath ?? '/v1/completions'
 			);
 
 			return commitMessages[0];


### PR DESCRIPTION
This PR lets you set your hostname and path, as well as change your auth type. This was driven by necessity to connect to the Azure instance of ChatGPT I wanted to connect to. I'm using this version to write my commit messages now. 

First, new configs:

    ./dist/cli.mjs config set OPENAI_KEY=****
    ./dist/cli.mjs config set authHeaderName=api-key
    ./dist/cli.mjs config set hostname=gpt4-resources.openai.azure.com
    ./dist/cli.mjs config set apipath='/openai/deployments/*****/chat/completions?api-version=2023-05-15'


OPENAI_KEY works with AuthHeaderName to create something like the below. Since we're not connecting to OpenAI, this should probably be renamed

      headers: {
        'api-key': '***',
        ...
      },
    # Or, by default
      headers: {
        'Authorization': 'Bearer sk-***',
        ...
      },

The fields `hostname` and `apipath` are probably self-explanatory. 

I'm failing some tests, but so is develop 🤔  So I'm not sure if this is a step back or something up with my local set up.
<img width="647" alt="image" src="https://github.com/Nutlope/aicommits/assets/1013261/2350d98d-77b4-46df-b48a-0204295df74d">
<img width="617" alt="image" src="https://github.com/Nutlope/aicommits/assets/1013261/51bb8bf7-679a-4758-aa51-eb8bc9a9c48f">

Looking forward to feedback!