### PR TITLE
chore: ignore binary lock files

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -23,6 +23,7 @@ const filesToExclude = [
 
 	// yarn.lock, Cargo.lock, Gemfile.lock, Pipfile.lock, etc.
 	'*.lock',
+	'*.lockb', // Binary lock file
 ].map(excludeFromDiff);
 
 export const getStagedDiff = async (excludeFiles?: string[]) => {


### PR DESCRIPTION
Ignore Binary lock files, like in Bun https://bun.sh/docs/install/lockfile