### PR TITLE
Add support for custom OpenAI URL

### DIFF
--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -65,6 +65,7 @@ export default async (
 		let messages: string[];
 		try {
 			messages = await generateCommitMessage(
+				config.openai_url,
 				config.OPENAI_KEY,
 				config.model,
 				config.locale,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,7 +27,7 @@ const configParsers = {
 				'Please set your OpenAI API key via `aicommits config set OPENAI_KEY=<your token>`'
 			);
 		}
-		parseAssert('OPENAI_KEY', key.startsWith('sk-'), 'Must start with "sk-"');
+		parseAssert('OPENAI_KEY', /^((sk-|no_api_key){1}[a-zA-Z0-9]*)$/.test(key), 'Must start with "sk-" or "no_api_key"');
 		// Key can range from 43~51 characters. There's no spec to assert this.
 
 		return key;
@@ -114,6 +114,15 @@ const configParsers = {
 		);
 
 		return parsed;
+	},
+	openai_url(url?: string) {
+		if (!url || url.length === 0) {
+			return undefined;
+		}
+
+		parseAssert('openai_url', /^https?:\/\//.test(url), 'Must be a valid URL');
+
+		return url;
 	},
 } as const;
 


### PR DESCRIPTION
Allows to run local OpenAI-compatible server. Since these local instances most likely lack proper certificates, allow using non-HTTPS endpoints as well.