### PR TITLE
Add support for specify the conventional commit type

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,12 @@ cli(
 				description: 'Type of commit message to generate',
 				alias: 't',
 			},
+			conventionalType: {
+				type: String,
+				description:
+					'Conventional commit type to generate if the type generated is not precise',
+				alias: 'c',
+			}
 		},
 
 		commands: [configCommand, hookCommand],
@@ -61,6 +67,7 @@ cli(
 				argv.flags.exclude,
 				argv.flags.all,
 				argv.flags.type,
+				argv.flags.type ? argv.flags.conventionalType : undefined,
 				rawArgv
 			);
 		}

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -22,6 +22,7 @@ export default async (
 	excludeFiles: string[],
 	stageAll: boolean,
 	commitType: string | undefined,
+	conventionalType: string | undefined,
 	rawArgv: string[]
 ) =>
 	(async () => {
@@ -58,6 +59,7 @@ export default async (
 				env.https_proxy || env.HTTPS_PROXY || env.http_proxy || env.HTTP_PROXY,
 			generate: generate?.toString(),
 			type: commitType?.toString(),
+			conventionalType: conventionalType?.toString(),
 		});
 
 		const s = spinner();
@@ -73,7 +75,8 @@ export default async (
 				config['max-length'],
 				config.type,
 				config.timeout,
-				config.proxy
+				config.proxy,
+				config.conventionalType
 			);
 		} finally {
 			s.stop('Changes analyzed');

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -115,6 +115,14 @@ const configParsers = {
 
 		return parsed;
 	},
+	conventionalType(type?: string) {
+		if (!type) {
+			return '';
+		}
+
+		parseAssert('conventionalType', type, 'Cannot be empty');
+		return type;
+	}
 } as const;
 
 type ConfigKeys = keyof typeof configParsers;

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -139,7 +139,8 @@ export const generateCommitMessage = async (
 	maxLength: number,
 	type: CommitType,
 	timeout: number,
-	proxy?: string
+	proxy?: string,
+	conventionalType?: string
 ) => {
 	try {
 		const completion = await createChatCompletion(
@@ -149,7 +150,7 @@ export const generateCommitMessage = async (
 				messages: [
 					{
 						role: 'system',
-						content: generatePrompt(locale, maxLength, type),
+						content: generatePrompt(locale, maxLength, type, conventionalType),
 					},
 					{
 						role: 'user',

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -7,6 +7,8 @@ const commitTypeFormats: Record<CommitType, string> = {
 const specifyCommitFormat = (type: CommitType) =>
 	`The output response must be in format:\n${commitTypeFormats[type]}`;
 
+const insertConventionalCommitType = (conventionalCommitType: string) => `With the type: ${conventionalCommitType}`;
+
 const commitTypes: Record<CommitType, string> = {
 	'': '',
 
@@ -41,14 +43,15 @@ const commitTypes: Record<CommitType, string> = {
 export const generatePrompt = (
 	locale: string,
 	maxLength: number,
-	type: CommitType
+	type: CommitType,
+	conventionalType?: string
 ) =>
 	[
 		'Generate a concise git commit message written in present tense for the following code diff with the given specifications below:',
 		`Message language: ${locale}`,
 		`Commit message must be a maximum of ${maxLength} characters.`,
 		'Exclude anything unnecessary such as translation. Your entire response will be passed directly into git commit.',
-		commitTypes[type],
+		conventionalType ? insertConventionalCommitType(conventionalType) : commitTypes[type],
 		specifyCommitFormat(type),
 	]
 		.filter(Boolean)


### PR DESCRIPTION
## DESCRIPTION

When using the cli, the AI sometimes generates inaccurate commit types. I wanted a way to force the conventional commit type by passing it directly in the cli.