### PR TITLE
Default model to `gpt-4.1-nano`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,9 @@ aicommits config set proxy=
 
 #### model
 
-Default: `gpt-3.5-turbo`
+Default: `gpt-4.1-nano`
 
 The Chat Completions (`/v1/chat/completions`) model to use. Consult the list of models available in the [OpenAI Documentation](https://platform.openai.com/docs/models/model-endpoint-compatibility).
-
-> Tip: If you have access, try upgrading to [`gpt-4`](https://platform.openai.com/docs/models/gpt-4) for next-level code analysis. It can handle double the input size, but comes at a higher cost. Check out OpenAI's website to learn more.
 
 #### timeout
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -82,7 +82,7 @@ const configParsers = {
 	},
 	model(model?: string) {
 		if (!model || model.length === 0) {
-			return 'gpt-3.5-turbo';
+			return 'gpt-4.1-nano';
 		}
 
 		return model as TiktokenModel;


### PR DESCRIPTION
Basically same price and gets 1m context length by default!

Pricing page: https://platform.openai.com/docs/pricing