### PR TITLE
fix: move exclude pathspecs after `--` separator in `getStagedDiffForFiles`

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -30,7 +30,8 @@ const isLockFile = (file: string) => {
 			// Simple glob match for *.lock
 			return file.endsWith('.lock');
 		}
-		return file === pattern;
+		// Match lock files by basename to handle subdirectories
+		return file.endsWith('/' + pattern) || file === pattern;
 	});
 };
 


### PR DESCRIPTION
`getStagedDiffForFiles` placed `:(exclude)` pathspecs before the `--` separator, causing git to interpret them as revisions
  instead of pathspecs.