### PR TITLE
Add subject+body format with separate description generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ aicommits --generate <i> # or -g <i>
 
 #### Commit Message Formats
 
-You can choose from three different commit message formats:
+You can choose from four different commit message formats:
 
 - **plain** (default): Simple, unstructured commit messages
 - **conventional**: [Conventional Commits](https://conventionalcommits.org/) format with type and scope
 - **gitmoji**: Emoji-based commit messages
+- **subject+body**: Git-style subject line plus a body (description) generated from the diff
 
 Use the `--type` flag to specify the format:
 
@@ -135,6 +136,7 @@ Use the `--type` flag to specify the format:
 aicommits --type conventional # or -t conventional
 aicommits --type gitmoji       # or -t gitmoji
 aicommits --type plain         # or -t plain (default)
+aicommits --type subject+body  # or -t subject+body (subject + body)
 ```
 
 This feature is useful if your project follows a specific commit message standard or if you're using tools that rely on these commit formats.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,7 @@ cli(
 			type: {
 				type: String,
 				description:
-					'Git commit message format (default: plain). Supports plain, conventional, and gitmoji',
+					'Git commit message format (default: plain). Supports plain, conventional, gitmoji, and subject+body',
 				alias: 't',
 			},
 			yes: {

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -313,49 +313,42 @@ export default async (
 			return;
 		}
 
-		// Commit the message with timeout
-			try {
-				const commitArgs = ['-m', message];
-				if (noVerify) {
-					commitArgs.push('--no-verify');
-				}
-				await execa('git', ['commit', ...commitArgs, ...rawArgv], {
-					stdio: 'inherit',
-					cleanup: true,
-					timeout: 10000
-				});
+		// Commit the message with timeout (use multiple -m for multi-line messages)
+		try {
+			const commitArgs =
+				message.includes('\n\n')
+					? ['-m', message.split(/\n\n/)[0], '-m', message.slice(message.indexOf('\n\n') + 2)]
+					: ['-m', message];
+			if (noVerify) {
+				commitArgs.push('--no-verify');
+			}
+			await execa('git', ['commit', ...commitArgs, ...rawArgv], {
+				stdio: 'inherit',
+				cleanup: true,
+				timeout: 10000,
+			});
 			outro(`${green('✔')} Successfully committed!`);
 		} catch (error: any) {
 			if (error.timedOut) {
-				// Copy to clipboard if commit times out
 				const success = await copyMessage(message);
 				if (success) {
 					outro(
-						`${yellow(
-							'⚠'
-						)} Commit timed out after 10 seconds. Message copied to clipboard.`
+						`${yellow('⚠')} Commit timed out after 10 seconds. Message copied to clipboard.`
 					);
 				} else {
 					outro(
-						`${yellow(
-							'⚠'
-						)} Commit timed out after 10 seconds. Could not copy to clipboard.`
+						`${yellow('⚠')} Commit timed out after 10 seconds. Could not copy to clipboard.`
 					);
 				}
 				return;
 			}
-
-			// Handle pre-commit hook failures or other git commit errors
 			if (error.exitCode !== undefined) {
-				outro(
-					`${red('✘')} Commit failed. This may be due to pre-commit hooks.`
-				);
+				outro(`${red('✘')} Commit failed. This may be due to pre-commit hooks.`);
 				console.error(
 					`  ${dim('Use')} --no-verify ${dim('to bypass pre-commit hooks')}`
 				);
 				process.exit(1);
 			}
-
 			throw error;
 		}
 	})().catch(handleCommandError);

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -19,6 +19,7 @@ import { getConfig, setConfigs } from '../utils/config-runtime.js';
 import { getProvider } from '../feature/providers/index.js';
 import {
 	generateCommitMessage,
+	generateCommitDescription,
 	combineCommitMessages,
 } from '../utils/openai.js';
 import { KnownError, handleCommandError } from '../utils/error.js';
@@ -133,8 +134,48 @@ export default async (
 			const baseUrl = providerInstance.getBaseUrl();
 			const apiKey = providerInstance.getApiKey() || '';
 			const providerHeaders = providerInstance.getHeaders();
+			const maxDiffLength = 30000;
+			let diffToUse = staged.diff;
+			if (diffToUse.length > maxDiffLength) {
+				diffToUse =
+					diffToUse.substring(0, maxDiffLength) +
+					'\n\n[Diff truncated due to size]';
+			}
 
-			if (isChunking) {
+			if (config.type === 'subject+body') {
+				const result = await generateCommitMessage({
+					baseUrl,
+					apiKey,
+					model: config.model!,
+					locale: config.locale,
+					diff: diffToUse,
+					completions: 1,
+					maxLength: config['max-length'],
+					type: 'subject+body',
+					timeout,
+					customPrompt,
+					headers: providerHeaders,
+				});
+				const title = result.messages[0];
+				const { description } = await generateCommitDescription({
+					baseUrl,
+					apiKey,
+					model: config.model!,
+					locale: config.locale,
+					title,
+					diff: diffToUse,
+					timeout,
+					maxLength: config['max-length'],
+					customPrompt,
+					headers: providerHeaders,
+				});
+				messages = [
+					description.trim()
+						? `${title}\n\n${description.trim()}`
+						: title,
+				];
+				usage = result.usage;
+			} else if (isChunking) {
 				// Split files into chunks
 				const chunks: string[][] = [];
 				for (let i = 0; i < staged.files.length; i += CHUNK_SIZE) {
@@ -220,14 +261,6 @@ export default async (
 				}
 				usage = totalUsage;
 			} else {
-				// Truncate diff if too large to avoid context limits
-				const maxDiffLength = 30000; // Approximate 7.5k tokens
-				let diffToUse = staged.diff;
-				if (diffToUse.length > maxDiffLength) {
-					diffToUse =
-						diffToUse.substring(0, maxDiffLength) +
-						'\n\n[Diff truncated due to size]';
-				}
 				const result = await generateCommitMessage({
 					baseUrl,
 					apiKey,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -128,6 +128,7 @@ export default command(
 					{ value: 'plain', label: 'Plain - Simple format without structure' },
 					{ value: 'conventional', label: 'Conventional - Standard conventional commits' },
 					{ value: 'gitmoji', label: 'Gitmoji - Using emojis for commit types' },
+					{ value: 'subject+body', label: 'Subject + body - Git-style subject line and body' },
 				],
 				initialValue: 'plain',
 			});

--- a/src/utils/config-types.ts
+++ b/src/utils/config-types.ts
@@ -1,6 +1,6 @@
 import { KnownError } from './error.js';
 
-const commitTypes = ['plain', 'conventional', 'gitmoji'] as const;
+const commitTypes = ['plain', 'conventional', 'gitmoji', 'subject+body'] as const;
 
 export type CommitType = (typeof commitTypes)[number];
 

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -3,7 +3,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { KnownError } from './error.js';
 import type { CommitType } from './config-types.js';
-import { generatePrompt, commitTypeFormats } from './prompt.js';
+import { generatePrompt, generateDescriptionPrompt } from './prompt.js';
 import { isHeadless } from './headless.js';
 
 const shouldLogDebug = () =>
@@ -41,6 +41,15 @@ const sanitizeMessage = (message: string) => {
  		.replace(/^<[^>]*>\s*/, ''); // Remove leading tags
 
  	return sanitized;
+};
+
+/** Sanitize description/body (multi-line): strip reasoning blocks, trim, remove surrounding quotes. */
+const sanitizeDescription = (message: string) => {
+	let processed = extractResponseFromReasoning(message);
+	return processed
+		.trim()
+		.replace(/^["'`]|["'`]$/g, '')
+		.replace(/^<[^>]*>\s*/, '');
 };
 
 const deduplicateMessages = (array: string[]) => Array.from(new Set(array));
@@ -201,7 +210,7 @@ export const generateCommitMessage = async ({
 
 		if (errorAsAny.status === 429) {
 			const resetHeader = errorAsAny.headers?.get('x-ratelimit-reset');
-			let message = 'Rate limit exceeded';
+			let rateLimitMessage = 'Rate limit exceeded';
 			if (resetHeader) {
 				const resetTime = parseInt(resetHeader);
 				const now = Date.now();
@@ -218,12 +227,125 @@ export const generateCommitMessage = async ({
 						const hours = Math.ceil(waitSec / 3600);
 						timeStr = `${hours} hour${hours === 1 ? '' : 's'}`;
 					}
-					message += `. Retry in ${timeStr}.`;
+					rateLimitMessage += `. Retry in ${timeStr}.`;
 				}
 			}
-			throw new KnownError(message);
+			throw new KnownError(rateLimitMessage);
 		}
 
+		throw errorAsAny;
+	}
+};
+
+export type GenerateCommitDescriptionOptions = {
+	baseUrl: string;
+	apiKey: string;
+	model: string;
+	locale: string;
+	title: string;
+	diff: string;
+	timeout: number;
+	maxLength: number;
+	customPrompt?: string;
+	headers?: Record<string, string>;
+};
+
+/**
+ * Wrap a single line at maxLength by breaking on spaces.
+ * Lines that start with "- " or "* " get continuation lines indented with 2 spaces for alignment.
+ */
+const wrapLine = (line: string, maxLength: number): string => {
+	const bulletMatch = /^([-*]\s)/.exec(line);
+	const indent = bulletMatch ? '  ' : '';
+	const continuationMax = maxLength - indent.length;
+
+	if (line.length <= maxLength) return line;
+
+	const parts: string[] = [];
+	let rest = line;
+	let isFirst = true;
+
+	while (rest.length > (isFirst ? maxLength : continuationMax)) {
+		const maxThisLine = isFirst ? maxLength : continuationMax;
+		const chunk = rest.slice(0, maxThisLine);
+		const lastSpace = chunk.lastIndexOf(' ');
+		const splitAt = lastSpace > 0 ? lastSpace + 1 : maxThisLine;
+		const segment = rest.slice(0, splitAt).trim();
+		parts.push(isFirst ? segment : indent + segment);
+		rest = rest.slice(splitAt).trim();
+		isFirst = false;
+	}
+	if (rest.length > 0) {
+		parts.push(isFirst ? rest : indent + rest);
+	}
+	return parts.join('\n');
+};
+
+export const generateCommitDescription = async ({
+	baseUrl,
+	apiKey,
+	model,
+	locale,
+	title,
+	diff,
+	timeout,
+	maxLength,
+	customPrompt,
+	headers,
+}: GenerateCommitDescriptionOptions) => {
+	if (shouldLogDebug()) {
+		console.log('Title and diff for description:');
+		console.log({ title, diffLength: diff.length });
+	}
+
+	const provider =
+		baseUrl === 'https://api.openai.com/v1'
+			? createOpenAI({ apiKey })
+			: createOpenAICompatible({
+					name: 'custom',
+					apiKey,
+					baseURL: baseUrl,
+					headers,
+			  });
+
+	const abortController = new AbortController();
+	const timeoutId = setTimeout(() => abortController.abort(), timeout);
+
+	try {
+		const result = await generateText({
+			model: provider(model),
+			system: generateDescriptionPrompt(locale, maxLength, customPrompt),
+			prompt: `Commit message title:\n${title}\n\nCode diff:\n${diff}`,
+			temperature: 0.4,
+			maxRetries: 2,
+			maxOutputTokens: 2000,
+			abortSignal: abortController.signal,
+		});
+		clearTimeout(timeoutId);
+		let description = sanitizeDescription(result.text);
+		// Enforce line length: wrap any line exceeding maxLength
+		description = description
+			.split('\n')
+			.map((line) => wrapLine(line, maxLength))
+			.join('\n');
+		return { description, usage: result.usage };
+	} catch (error) {
+		clearTimeout(timeoutId);
+		const errorAsAny = error as any;
+		if (
+			errorAsAny.name === 'AbortError' ||
+			errorAsAny.message?.includes('aborted') ||
+			errorAsAny.message?.includes('This operation was aborted')
+		) {
+			throw new KnownError(
+				`Request timed out after ${timeout / 1000} seconds. The API took too long to respond. Try again or use a different model.`
+			);
+		}
+		if (errorAsAny.code === 'ENOTFOUND') {
+			throw new KnownError(
+				`Error connecting to ${errorAsAny.hostname} (${errorAsAny.syscall}). Are you connected to the internet?`
+			);
+		}
 		throw errorAsAny;
 	}
 };

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -4,6 +4,7 @@ export const commitTypeFormats: Record<CommitType, string> = {
 	plain: '<commit message>',
 	conventional: '<type>[optional (<scope>)]: <commit message>\nThe commit message subject must start with a lowercase letter',
 	gitmoji: ':emoji: <commit message>',
+	'subject+body': '<commit message subject>',
 };
 const specifyCommitFormat = (type: CommitType) =>
 	`The output response must be in format:\n${commitTypeFormats[type]}`;
@@ -121,6 +122,7 @@ const commitTypes: Record<CommitType, string> = {
 		null,
 		2
 	)}`,
+	'subject+body': 'Output only the subject line; the body is generated separately.',
 };
 
 export const generatePrompt = (
@@ -139,6 +141,26 @@ export const generatePrompt = (
 		customPrompt,
 		commitTypes[type],
 		specifyCommitFormat(type),
+	]
+		.filter(Boolean)
+		.join('\n');
+
+/**
+ * Prompt for generating a commit message body/description given a title and diff.
+ * Used when the user has (or generated) a title and wants a detailed description.
+ */
+export const generateDescriptionPrompt = (
+	locale: string,
+	maxLength: number,
+	customPrompt?: string
+) =>
+	[
+		'You are generating the short body (description) of a git commit message. You are given the commit title and the code diff.',
+		'Output must be brief: use 3–6 bullet points (one short line each), or 2–4 short sentences. No long paragraphs. Focus on what changed and why, in present tense.',
+		`Git convention: each line at most ${maxLength} characters. When a bullet line wraps, indent the continuation with 2 spaces so it aligns under the bullet text.`,
+		'Do not repeat the title. No meta-commentary (e.g. "This commit..."). Respond with ONLY the commit body.',
+		`Message language: ${locale}`,
+		customPrompt,
 	]
 		.filter(Boolean)
 		.join('\n');

--- a/tests/specs/cli/commits.ts
+++ b/tests/specs/cli/commits.ts
@@ -385,6 +385,43 @@ export default testSuite(({ describe }) => {
 
 				await fixture.rm();
 			});
+
+			test('subject+body generates commit with subject and body', async () => {
+				const { fixture, aicommits } = await createFixture({
+					...files,
+					'.aicommits': `${files['.aicommits']}\ntype=subject+body`,
+				});
+				const git = await createGit(fixture.path);
+
+				await git('add', ['data.json']);
+
+				const committing = aicommits();
+
+				committing.stdout!.on('data', (buffer: Buffer) => {
+					const stdout = buffer.toString();
+					if (stdout.match('└')) {
+						committing.stdin!.write('y');
+						committing.stdin!.end();
+					}
+				});
+
+				await committing;
+
+				const statusAfter = await git('status', [
+					'--porcelain',
+					'--untracked-files=no',
+				]);
+				expect(statusAfter.stdout).toBe('');
+
+				const { stdout: fullMessage } = await git('log', [
+					'-n1',
+					'--pretty=format:%B',
+				]);
+				expect(fullMessage).toContain('\n');
+				expect(fullMessage.trim().split('\n').length).toBeGreaterThanOrEqual(2);
+
+				await fixture.rm();
+			});
 		});
 
 		describe('proxy', ({ test }) => {

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -72,6 +72,13 @@ export default testSuite(({ describe }) => {
 			});
 		});
 
+		test('accepts type=subject+body', async () => {
+			await aicommits(['config', 'set', 'OPENAI_API_KEY=abc']);
+			await aicommits(['config', 'set', 'type=subject+body']);
+			const { stdout } = await aicommits(['config', 'get', 'type']);
+			expect(stdout).toBe('type=subject+body');
+		});
+
 		await describe('max-length', ({ test }) => {
 			test('must be an integer', async () => {
 				const { stderr } = await aicommits(

--- a/tests/specs/openai/index.ts
+++ b/tests/specs/openai/index.ts
@@ -1,5 +1,8 @@
 import { expect, testSuite } from 'manten';
-import { generateCommitMessage } from '../../../src/utils/openai.js';
+import {
+	generateCommitMessage,
+	generateCommitDescription,
+} from '../../../src/utils/openai.js';
 import type { ValidConfig } from '../../../src/utils/config-types.js';
 import { getDiff } from '../../utils.js';
 
@@ -152,5 +155,26 @@ export default testSuite(({ describe }) => {
 
 			return commitMessages[0];
 		}
+	});
+
+	describe('subject+body / generateCommitDescription', async ({ test }) => {
+		await test('generates a non-empty body from title and diff', async () => {
+			const gitDiff = await getDiff('new-feature.diff');
+			const title = 'feat: add new feature';
+
+			const { description } = await generateCommitDescription({
+				baseUrl: 'https://api.openai.com/v1',
+				apiKey: OPENAI_API_KEY!,
+				model: 'gpt-3.5-turbo',
+				locale: 'en',
+				title,
+				diff: gitDiff,
+				timeout: 7000,
+				maxLength: 72,
+			});
+
+			expect(typeof description).toBe('string');
+			expect(description.length).toBeGreaterThan(0);
+		});
 	});
 });

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -51,6 +51,11 @@
 				"icon": "$(symbol-enum)"
 			},
 			{
+				"command": "aicommits.generateSubjectBody",
+				"title": "AI Commits: Generate Subject+Body Commit",
+				"icon": "$(list-unordered)"
+			},
+			{
 				"command": "aicommits.setup",
 				"title": "AI Commits: Setup Provider"
 			},
@@ -89,7 +94,8 @@
 					"enum": [
 						"plain",
 						"conventional",
-						"gitmoji"
+						"gitmoji",
+						"subject+body"
 					],
 					"description": "Default commit message format"
 				},

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -18,10 +18,9 @@ export function activate(context: vscode.ExtensionContext) {
 		'aicommits.generate',
 		() => {
 			const config = vscode.workspace.getConfiguration('aicommits');
-			const defaultType = config.get<'plain' | 'conventional' | 'gitmoji'>(
-				'defaultType',
-				'plain',
-			);
+			const defaultType = config.get<
+				'plain' | 'conventional' | 'gitmoji' | 'subject+body'
+			>('defaultType', 'plain');
 			return generateCommitMessage(defaultType);
 		},
 	);
@@ -34,6 +33,11 @@ export function activate(context: vscode.ExtensionContext) {
 	const generateGitmojiCommand = vscode.commands.registerCommand(
 		'aicommits.generateGitmoji',
 		() => generateCommitMessage('gitmoji'),
+	);
+
+	const generateSubjectBodyCommand = vscode.commands.registerCommand(
+		'aicommits.generateSubjectBody',
+		() => generateCommitMessage('subject+body'),
 	);
 
 	const setupCommand = vscode.commands.registerCommand('aicommits.setup', () =>
@@ -49,6 +53,7 @@ export function activate(context: vscode.ExtensionContext) {
 		generateCommand,
 		generateConventionalCommand,
 		generateGitmojiCommand,
+		generateSubjectBodyCommand,
 		setupCommand,
 		selectModelCommand,
 		outputChannel,
@@ -252,7 +257,7 @@ async function ensureCliInstalled(): Promise<boolean> {
 }
 
 async function generateCommitMessage(
-	type: 'plain' | 'conventional' | 'gitmoji',
+	type: 'plain' | 'conventional' | 'gitmoji' | 'subject+body',
 ) {
 	if (!(await ensureCliInstalled())) {
 		return;


### PR DESCRIPTION
- Add `subject+body` format option: generates a subject line and a separate description body
- Introduce `generateCommitDescription` function to produce a concise, bullet-pointed description
- Truncate large diffs before processing to avoid context limits
- Update CLI help text, config types, and setup prompts to include the new format
- Sanitize and wrap description lines to comply with Git conventions