### PR TITLE
fix: remove model list cache that serves stale data

### DIFF
--- a/src/feature/models.ts
+++ b/src/feature/models.ts
@@ -1,12 +1,7 @@
 // Model filtering, fetching, and selection utilities
-import fs from 'fs/promises';
-import path from 'path';
-import os from 'os';
-import crypto from 'crypto';
 import type { ProviderDef } from './providers/base.js';
 import { CURRENT_LABEL_FORMAT } from '../utils/constants.js';
 import { isCancel, spinner } from '@clack/prompts';
-import { fileExists } from '../utils/fs.js';
 
 interface ModelObject {
 	id?: string;
@@ -14,73 +9,11 @@ interface ModelObject {
 	type?: string;
 }
 
-interface CacheEntry {
-	data: { models: ModelObject[]; error?: string };
-	timestamp: number;
-}
-
-const CACHE_DURATION = 60 * 60 * 1000; // 1 hour in milliseconds
-
-const getCacheDir = (): string => {
-	const platform = process.platform;
-	const home = os.homedir();
-
-	if (platform === 'darwin') {
-		return path.join(home, 'Library', 'Caches', 'aicommits', 'models');
-	} else if (platform === 'win32') {
-		return path.join(home, 'AppData', 'Local', 'aicommits', 'models');
-	} else {
-		// Linux/Unix
-		const xdgCache = process.env.XDG_CACHE_HOME;
-		const baseCache = xdgCache ? xdgCache : path.join(home, '.cache');
-		return path.join(baseCache, 'aicommits', 'models');
-	}
-};
-
-const getCacheKey = (baseUrl: string): string => {
-	const hash = crypto.createHash('sha256');
-	hash.update(baseUrl);
-	return hash.digest('hex');
-};
-
-const getCachePath = (key: string): string =>
-	path.join(getCacheDir(), `${key}.json`);
-
-const readCache = async (key: string): Promise<CacheEntry | null> => {
-	const cachePath = getCachePath(key);
-	try {
-		if (!(await fileExists(cachePath))) return null;
-		const data = await fs.readFile(cachePath, 'utf8');
-		return JSON.parse(data);
-	} catch {
-		return null;
-	}
-};
-
-const writeCache = async (key: string, entry: CacheEntry): Promise<void> => {
-	try {
-		const cacheDir = getCacheDir();
-		await fs.mkdir(cacheDir, { recursive: true });
-		const cachePath = getCachePath(key);
-		await fs.writeFile(cachePath, JSON.stringify(entry), 'utf8');
-	} catch {
-		// Ignore write errors
-	}
-};
-
 // Fetch models from API
 export const fetchModels = async (
 	baseUrl: string,
 	apiKey: string,
 ): Promise<{ models: ModelObject[]; error?: string }> => {
-	const cacheKey = getCacheKey(baseUrl);
-	const now = Date.now();
-	const cached = await readCache(cacheKey);
-
-	if (cached && now - cached.timestamp < CACHE_DURATION) {
-		return cached.data;
-	}
-
 	try {
 		const response = await fetch(`${baseUrl}/models`, {
 			headers: {
@@ -97,16 +30,11 @@ export const fetchModels = async (
 		// we do this since Together API for openai models has different response than standard needing just data, other apis data.data
 		const modelsArray: ModelObject[] = (data.data ? data.data : data) || [];
 
-		const result = { models: modelsArray };
-		if (modelsArray.length > 0) {
-			await writeCache(cacheKey, { data: result, timestamp: now });
-		}
-		return result;
+		return { models: modelsArray };
 	} catch (error: unknown) {
 		const errorMessage =
 			error instanceof Error ? error.message : 'Request failed';
-		const result = { models: [], error: errorMessage };
-		return result;
+		return { models: [], error: errorMessage };
 	}
 };
 


### PR DESCRIPTION
Closes #332

## Summary
- Removed the 1-hour model list cache from `fetchModels` in `src/feature/models.ts`
- The cache caused `aicommits setup` / `aicommits model` to show outdated models when users added or removed models between sessions
- Model fetching only happens during interactive setup/model selection, so the cache provided no meaningful performance benefit

## Test plan
- [x] Run `aicommits setup` with Ollama — models reflect current `ollama list`
- [x] Add/remove a model, re-run setup — list updates immediately
- [x] `pnpm build` succeeds