### PR TITLE
feat: add wl-copy support and ignore stdio for Linux clipboard

### DIFF
--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -4,7 +4,7 @@ import { execa } from 'execa';
  * Copy text to the system clipboard using native CLI tools.
  * macOS: pbcopy
  * Windows: clip
- * Linux: xclip (fallback to xsel)
+ * Linux: wl-copy (Wayland), xclip or xsel (X11)
  */
 export async function copyToClipboard(message: string): Promise<boolean> {
 	try {
@@ -15,10 +15,28 @@ export async function copyToClipboard(message: string): Promise<boolean> {
 			// Windows - use clip
 			await execa('clip', { input: message });
 		} else {
-			// Linux - try xclip first, fallback to xsel
-			await execa('xclip', ['-selection', 'clipboard'], { input: message }).catch(
-				() => execa('xsel', ['--clipboard', '--input'], { input: message }),
-			);
+			/**
+			 * Linux:
+			 * Ignore stdout/stderr to prevent the CLI from hanging while
+			 * Linux clipboard tools fork background processes to serve the content.
+			 */
+			const options = {
+				input: message,
+				stdio: ['pipe', 'ignore', 'ignore'] as const,
+			};
+
+			try {
+				// Try Wayland (wl-copy)
+				await execa('wl-copy', options);
+			} catch {
+				try {
+					// Fallback to xclip (X11)
+					await execa('xclip', ['-selection', 'clipboard'], options);
+				} catch {
+					// Fallback to xsel (X11)
+					await execa('xsel', ['--clipboard', '--input'], options);
+				}
+			}
 		}
 		return true;
 	} catch {


### PR DESCRIPTION
**Description:**
This PR improves the clipboard functionality for Linux users and fixes a common issue where the CLI hangs after copying text.

**Changes:**
1.  **Added Wayland Support:** Added `wl-copy` to the Linux execution chain. This ensures the clipboard works natively on modern Linux distributions using Wayland (e.g., Fedora, Ubuntu, Arch).
2.  **Fixed Process Hanging:** Introduced `stdio: 'ignore'` for `stdout` and `stderr` when calling Linux clipboard utilities.

**Why are these changes necessary?**
On Linux, utilities like `wl-copy` or `xclip` do not simply "set" the clipboard and exit. Instead, they often spawn a background process (daemon) to serve the clipboard content to other applications.

By default, `execa` waits for all output streams (`stdout`/`stderr`) to close before resolving the Promise. Since the background daemon keeps these streams open, the CLI stays active and "hangs" for 20-30 seconds until the daemon automatically times out or is terminated. 

By ignoring `stdout` and `stderr`, we allow `execa` to resolve as soon as the text is successfully piped into the utility's `stdin`, making the copy operation feel instantaneous.