### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/src/feature/providers/novita.ts
+++ b/src/feature/providers/novita.ts
@@ -1,0 +1,20 @@
+import { ProviderDef } from './base.js';
+
+export const NovitaProvider: ProviderDef = {
+	name: 'novita',
+	displayName: 'Novita AI',
+	baseUrl: 'https://api.novita.ai/openai/v1',
+	modelsFilter: (models) =>
+		models
+			.filter(
+				(m: any) =>
+					m.id && (!m.type || m.type === 'chat' || m.type === 'language'),
+			)
+			.map((m: any) => m.id),
+	defaultModels: [
+		'moonshotai/kimi-k2.5',
+		'zai-org/glm-5',
+		'minimax/minimax-m2.5',
+	],
+	requiresApiKey: true,
+};

--- a/src/feature/providers/providers-data.ts
+++ b/src/feature/providers/providers-data.ts
@@ -6,12 +6,14 @@ import { OpenRouterProvider } from './openrouter.js';
 import { LMStudioProvider } from './lmstudio.js';
 import { GroqProvider } from './groq.js';
 import { XAiProvider } from './xai.js';
+import { NovitaProvider } from './novita.js';
 
 export const providers = [
 	TogetherProvider,
 	OpenAiProvider,
 	GroqProvider,
 	XAiProvider,
+	NovitaProvider,
 	OllamaProvider,
 	LMStudioProvider,
 	OpenRouterProvider,

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -5,6 +5,7 @@ describe('aicommits', ({ runTestSuite }) => {
 	runTestSuite(import('./specs/auto-update.js'));
 	runTestSuite(import('./specs/openai/index.js'));
 	runTestSuite(import('./specs/togetherai/index.js'));
+	runTestSuite(import('./specs/novita/index.js'));
 	runTestSuite(import('./specs/config.js'));
 	runTestSuite(import('./specs/git-hook.js'));
 });

--- a/tests/specs/novita/index.ts
+++ b/tests/specs/novita/index.ts
@@ -1,0 +1,81 @@
+import { expect, testSuite } from 'manten';
+import { generateCommitMessage } from '../../../src/utils/openai.js';
+import type { ValidConfig } from '../../../src/utils/config-types.js';
+import { getDiff } from '../../utils.js';
+
+const { NOVITA_API_KEY } = process.env;
+
+export default testSuite(({ describe }) => {
+	if (!NOVITA_API_KEY) {
+		console.warn(
+			'⚠️  process.env.NOVITA_API_KEY is necessary to run these tests. Skipping...',
+		);
+		return;
+	}
+
+	describe('Conventional Commits', async ({ test }) => {
+		await test('Should generate conventional commit format', async () => {
+			const gitDiff = await getDiff('new-feature.diff');
+
+			const commitMessage = await runGenerateCommitMessage(gitDiff, {
+				locale: 'en',
+			});
+
+			// Should start with conventional commit type
+			expect(commitMessage).toMatch(
+				/^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)/,
+			);
+			console.log('Generated message:', commitMessage);
+		});
+
+		await test('Should generate conventional commit for new feature', async () => {
+			const gitDiff = await getDiff('new-feature.diff');
+
+			const commitMessage = await runGenerateCommitMessage(gitDiff);
+
+			// Should be in conventional commit format
+			expect(commitMessage).toMatch(
+				/^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)/,
+			);
+			console.log('Generated message:', commitMessage);
+		});
+
+		await test('Should generate conventional commit for refactoring', async () => {
+			const gitDiff = await getDiff('code-refactoring.diff');
+
+			const commitMessage = await runGenerateCommitMessage(gitDiff);
+
+			// Should be in conventional commit format
+			expect(commitMessage).toMatch(
+				/^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)/,
+			);
+			console.log('Generated message:', commitMessage);
+		});
+
+		async function runGenerateCommitMessage(
+			gitDiff: string,
+			configOverrides: Partial<ValidConfig> = {},
+		): Promise<string> {
+			const config = {
+				locale: 'en',
+				type: 'conventional',
+				generate: 1,
+				'max-length': 72,
+				...configOverrides,
+			} as ValidConfig;
+			const { messages: commitMessages } = await generateCommitMessage({
+				baseUrl: 'https://api.novita.ai/openai/v1',
+				apiKey: NOVITA_API_KEY!,
+				model: 'moonshotai/kimi-k2.5',
+				locale: config.locale,
+				diff: gitDiff,
+				completions: config.generate,
+				maxLength: config['max-length'],
+				type: config.type,
+				timeout: 30000,
+			});
+
+			return commitMessages[0];
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Add [Novita AI](https://novita.ai) as a new LLM provider. Novita offers an OpenAI-compatible API with competitive pricing and a wide selection of open-source models.

### Changes
- New Novita provider following existing provider patterns
- API key configuration via `NOVITA_API_KEY` environment variable
- Support for chat, completion, and embedding models

### Configuration
```
NOVITA_API_KEY=your_key_here
```

**Endpoint**: `https://api.novita.ai/openai`