### PR TITLE
feat: add Anthropic provider with proper model listing headers

### DIFF
--- a/src/feature/models.ts
+++ b/src/feature/models.ts
@@ -71,6 +71,7 @@ const writeCache = async (key: string, entry: CacheEntry): Promise<void> => {
 interface FetchModelsOptions {
 	baseUrl: string;
 	apiKey?: string;
+	headers?: Record<string, string>;
 	cacheModels?: boolean;
 }
 
@@ -78,7 +79,7 @@ interface FetchModelsOptions {
 export const fetchModels = async (
 	options: FetchModelsOptions,
 ): Promise<{ models: ModelObject[]; error?: string }> => {
-	const { baseUrl, apiKey = '', cacheModels = true } = options;
+	const { baseUrl, apiKey = '', headers, cacheModels = true } = options;
 	const cacheKey = getCacheKey(baseUrl);
 	const now = Date.now();
 
@@ -91,7 +92,7 @@ export const fetchModels = async (
 
 	try {
 		const response = await fetch(`${baseUrl}/models`, {
-			headers: {
+			headers: headers || {
 				Authorization: `Bearer ${apiKey}`,
 			},
 		});
@@ -124,10 +125,12 @@ const fetchAndFilterModels = async (
 	apiKey: string,
 	providerDef?: ProviderDef,
 ): Promise<string[]> => {
-	// Fetch models
+	// Fetch models, passing provider-specific headers when available (e.g. Anthropic requires x-api-key instead of Bearer)
+	const headers = providerDef?.modelHeaders?.(apiKey);
 	const result = await fetchModels({
 		baseUrl,
 		apiKey,
+		headers,
 		cacheModels: providerDef?.cacheModels,
 	});
 

--- a/src/feature/providers/anthropic.ts
+++ b/src/feature/providers/anthropic.ts
@@ -1,0 +1,18 @@
+import type { ProviderDef } from './base.js';
+
+export const AnthropicProvider: ProviderDef = {
+	name: 'anthropic',
+	displayName: 'Anthropic',
+	baseUrl: 'https://api.anthropic.com/v1',
+	apiKeyFormat: 'sk-ant-',
+	modelHeaders: (apiKey) => ({
+		'x-api-key': apiKey,
+		'anthropic-version': '2023-06-01',
+	}),
+	modelsFilter: (models) =>
+		models
+			.filter((m: any) => m.id && m.id.includes('claude'))
+			.map((m: any) => m.id),
+	defaultModels: ['claude-sonnet-4-5-20250514', 'claude-haiku-4-5-20251001', 'claude-opus-4-20250115'],
+	requiresApiKey: true,
+};

--- a/src/feature/providers/base.ts
+++ b/src/feature/providers/base.ts
@@ -10,6 +10,7 @@ export type ProviderDef = {
 	defaultModels: string[];
 	requiresApiKey: boolean;
 	headers?: Record<string, string>;
+	modelHeaders?: (apiKey: string) => Record<string, string>;
 	cacheModels?: boolean;
 	isLocal?: boolean;
 };
@@ -81,9 +82,11 @@ export class Provider {
 	async getModels(): Promise<{ models: string[]; error?: string }> {
 		const baseUrl = this.getBaseUrl();
 		const apiKey = this.getApiKey() || '';
+		const headers = this.def.modelHeaders?.(apiKey);
 		const result = await fetchModels({
 			baseUrl,
 			apiKey,
+			headers,
 			cacheModels: this.def.cacheModels,
 		});
 		if (result.error) return { models: [], error: result.error };

--- a/src/feature/providers/providers-data.ts
+++ b/src/feature/providers/providers-data.ts
@@ -6,10 +6,12 @@ import { OpenRouterProvider } from './openrouter.js';
 import { LMStudioProvider } from './lmstudio.js';
 import { GroqProvider } from './groq.js';
 import { XAiProvider } from './xai.js';
+import { AnthropicProvider } from './anthropic.js';
 
 export const providers = [
 	TogetherProvider,
 	OpenAiProvider,
+	AnthropicProvider,
 	GroqProvider,
 	XAiProvider,
 	OllamaProvider,


### PR DESCRIPTION
- Add AnthropicProvider definition (claude-sonnet/haiku/opus defaults)
- Register AnthropicProvider in providers-data.ts
- Add modelHeaders field to ProviderDef for provider-specific auth headers
- Fix fetchAndFilterModels and fetchModels to pass provider headers, resolving Anthropic's x-api-key/anthropic-version requirement instead of standard Bearer token auth