### PR TITLE
fix: update Together AI default models after deprecations

### DIFF
--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -96,7 +96,7 @@ export default async (
 
 		// Use config timeout, or default per provider
 		const timeout =
-			config.timeout || (providerInstance.name === 'ollama' ? 30_000 : 10_000);
+			config.timeout || (providerInstance.name === 'ollama' ? 30_000 : 15_000);
 
 		// Validate provider config
 		const validation = providerInstance.validateConfig();

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -59,7 +59,7 @@ export default () =>
 
 		// Use config timeout, or default per provider
 		const timeout =
-			config.timeout || (providerInstance.name === 'ollama' ? 30_000 : 10_000);
+			config.timeout || (providerInstance.name === 'ollama' ? 30_000 : 15_000);
 
 		// Use the unified model or provider default
 		let model = config.OPENAI_MODEL || providerInstance.getDefaultModel();

--- a/src/feature/providers/together.ts
+++ b/src/feature/providers/together.ts
@@ -14,9 +14,9 @@ export const TogetherProvider: ProviderDef = {
 			)
 			.map((m: any) => m.id),
 	defaultModels: [
-		'Qwen/Qwen3-Next-80B-A3B-Instruct',
-		'zai-org/GLM-4.5-Air-FP8',
-		'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+		'deepseek-ai/DeepSeek-V3.1',
+		'Qwen/Qwen3.5-9B',
+		'Qwen/Qwen3.5-397B-A17B',
 	],
 	requiresApiKey: true,
 };

--- a/tests/specs/togetherai/index.ts
+++ b/tests/specs/togetherai/index.ts
@@ -66,7 +66,7 @@ export default testSuite(({ describe }) => {
 			const { messages: commitMessages } = await generateCommitMessage({
 				baseUrl: 'https://api.together.xyz',
 				apiKey: TOGETHER_API_KEY!,
-				model: 'Qwen/Qwen3-Next-80B-A3B-Instruct',
+				model: 'deepseek-ai/DeepSeek-V3.1',
 				locale: config.locale,
 				diff: gitDiff,
 				completions: config.generate,


### PR DESCRIPTION
- Replace deprecated models (Qwen3-Next-80B, GLM-4.5-Air-FP8, Llama-3.1-8B-Turbo)
- Add DeepSeek-V3.1 as new primary default (671B, serverless)
- Add Qwen3.5-9B as affordable alternative ($0.10/1M input)
- Add Qwen3.5-397B-A17B as powerful alternative (403B, serverless)