### PR TITLE
[339] fix: handle provider returned error in OpenAI functions

### DIFF
--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -233,6 +233,12 @@ export const generateCommitMessage = async ({
 			throw new KnownError(rateLimitMessage);
 		}
 
+		if (errorAsAny.message?.includes('Provider returned error')) {
+			throw new KnownError(
+				`Provider failed to process your request. Try running the command again, or switch to a different model with \`aicommits model\`.`
+			);
+		}
+
 		throw errorAsAny;
 	}
 };
@@ -346,6 +352,11 @@ export const generateCommitDescription = async ({
 				`Error connecting to ${errorAsAny.hostname} (${errorAsAny.syscall}). Are you connected to the internet?`
 			);
 		}
+		if (errorAsAny.message?.includes('Provider returned error')) {
+			throw new KnownError(
+				`Provider failed to process your request. Try running the command again, or switch to a different model with \`aicommits model\`.`
+			);
+		}
 		throw errorAsAny;
 	}
 };
@@ -431,6 +442,12 @@ Do not add thanks, explanations, or any text outside the commit message.`;
 		) {
 			throw new KnownError(
 				`Request timed out after ${timeout / 1000} seconds. The API took too long to respond. Try again or use a different model.`
+			);
+		}
+
+		if (errorAsAny.message?.includes('Provider returned error')) {
+			throw new KnownError(
+				`Provider failed to process your request. Try running the command again, or switch to a different model with \`aicommits model\`.`
 			);
 		}
 


### PR DESCRIPTION
**Fix**: Issue #339 

Adding a capture to the provider's unknown error:

---

✖ Failed after 3 attempts. Last error: Provider returned error
    at _retryWithExponentialBackoff (file:///home/user/.nvm/versions/node/v22.21.0/lib/node_modules/aicommits/dist/cli-ekP4p-Xo.mjs:148:5441)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async fn (file:///home/user/.nvm/versions/node/v22.21.0/lib/node_modules/aicommits/dist/cli-ekP4p-Xo.mjs:149:19449)
    at async file:///home/user/.nvm/versions/node/v22.21.0/lib/node_modules/aicommits/dist/cli-ekP4p-Xo.mjs:148:1561
    at async generateText (file:///home/user/.nvm/versions/node/v22.21.0/lib/node_modules/aicommits/dist/cli-ekP4p-Xo.mjs:149:16820)
    at async Promise.all (index 0)
    at async file:///home/user/.nvm/versions/node/v22.21.0/lib/node_modules/aicommits/dist/cli-ekP4p-Xo.mjs:180:1317
    at async generateCommitMessage (file:///home/user/.nvm/versions/node/v22.21.0/lib/node_modules/aicommits/dist/cli-ekP4p-Xo.mjs:180:1290)
    at async file:///home/user/.nvm/versions/node/v22.21.0/lib/node_modules/aicommits/dist/cli-ekP4p-Xo.mjs:203:846
