### PR TITLE
feat: add conventional+body commit message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This will guide you through:
 - Selecting your AI provider (sets the `provider` config)
 - Configuring your API key
 - **Automatically fetching and selecting from available models** (when supported)
-- **Choosing your preferred commit message format** (plain, conventional, or gitmoji)
+- **Choosing your preferred commit message format** (plain, conventional, conventional+body, gitmoji, or subject+body)
 
   Supported providers include:
 
@@ -106,7 +106,7 @@ aicommits --all # or -a
 - `--clipboard` or `-c`: Copy the selected message to the clipboard instead of committing (default: **false**)
 - `--generate` or `-g`: Number of messages to generate (default: **1**)
 - `--exclude` or `-x`: Files to exclude from AI analysis
-- `--type` or `-t`: Git commit message format (default: **plain**). Supports `plain`, `conventional`, and `gitmoji`
+- `--type` or `-t`: Git commit message format (default: **plain**). Supports `plain`, `conventional`, `conventional+body`, `gitmoji`, and `subject+body`
 - `--prompt` or `-p`: Custom prompt to guide the LLM behavior (e.g., specific language, style instructions)
 - `--no-verify` or `-n`: Bypass pre-commit hooks while committing (default: **false**)
 - `--yes` or `-y`: Skip confirmation when committing after message generation (default: **false**)
@@ -123,20 +123,22 @@ aicommits --generate <i> # or -g <i>
 
 #### Commit Message Formats
 
-You can choose from four different commit message formats:
+You can choose from five different commit message formats:
 
 - **plain** (default): Simple, unstructured commit messages
 - **conventional**: [Conventional Commits](https://conventionalcommits.org/) format with type and scope
+- **conventional+body**: Conventional commit subject plus a body generated from the diff
 - **gitmoji**: Emoji-based commit messages
 - **subject+body**: Git-style subject line plus a body (description) generated from the diff
 
 Use the `--type` flag to specify the format:
 
 ```sh
-aicommits --type conventional # or -t conventional
-aicommits --type gitmoji       # or -t gitmoji
-aicommits --type plain         # or -t plain (default)
-aicommits --type subject+body  # or -t subject+body (subject + body)
+aicommits --type conventional      # or -t conventional
+aicommits --type conventional+body # or -t conventional+body (conventional subject + body)
+aicommits --type gitmoji           # or -t gitmoji
+aicommits --type plain             # or -t plain (default)
+aicommits --type subject+body      # or -t subject+body (subject + body)
 ```
 
 This feature is useful if your project follows a specific commit message standard or if you're using tools that rely on these commit formats.

--- a/README.md
+++ b/README.md
@@ -358,14 +358,18 @@ The type of commit message to generate. Available options:
 
 - `plain`: Simple, unstructured commit messages
 - `conventional`: Conventional Commits format with type and scope
+- `conventional+body`: Conventional commit subject plus a body generated from the diff
 - `gitmoji`: Emoji-based commit messages
+- `subject+body`: Git-style subject line plus a body generated from the diff
 
 Examples:
 
 ```sh
 aicommits config set type=conventional
+aicommits config set type=conventional+body
 aicommits config set type=gitmoji
 aicommits config set type=plain
+aicommits config set type=subject+body
 ```
 
 ## How it works

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,7 @@ cli(
 			type: {
 				type: String,
 				description:
-					'Git commit message format (default: plain). Supports plain, conventional, gitmoji, and subject+body',
+					'Git commit message format (default: plain). Supports plain, conventional, conventional+body, gitmoji, and subject+body',
 				alias: 't',
 			},
 			yes: {

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -142,7 +142,7 @@ export default async (
 					'\n\n[Diff truncated due to size]';
 			}
 
-			if (config.type === 'subject+body') {
+			if (config.type === 'conventional+body' || config.type === 'subject+body') {
 				const result = await generateCommitMessage({
 					baseUrl,
 					apiKey,
@@ -151,7 +151,7 @@ export default async (
 					diff: diffToUse,
 					completions: 1,
 					maxLength: config['max-length'],
-					type: 'subject+body',
+					type: config.type,
 					timeout,
 					customPrompt,
 					headers: providerHeaders,

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -4,7 +4,7 @@ import { black, green, red, bgCyan } from 'kolorist';
 import { getStagedDiff } from '../utils/git.js';
 import { getConfig } from '../utils/config-runtime.js';
 import { getProvider } from '../feature/providers/index.js';
-import { generateCommitMessage } from '../utils/openai.js';
+import { generateCommitMessage, generateCommitDescription } from '../utils/openai.js';
 import { KnownError, handleCommandError } from '../utils/error.js';
 import { isHeadless } from '../utils/headless.js';
 
@@ -67,20 +67,53 @@ export default () =>
 		const s = headless ? null : spinner();
 		s?.start('The AI is analyzing your changes');
 		let messages: string[];
+		const maxDiffLength = 30000;
+		const diffToUse =
+			staged!.diff.length > maxDiffLength
+				? staged!.diff.substring(0, maxDiffLength) + '\n\n[Diff truncated due to size]'
+				: staged!.diff;
 		try {
-			const result = await generateCommitMessage({
-				baseUrl,
-				apiKey,
-				model,
-				locale: config.locale,
-				diff: staged!.diff,
-				completions: config.generate,
-				maxLength: config['max-length'],
-				type: config.type,
-				timeout,
-				headers: providerHeaders,
-			});
-			messages = result.messages;
+			if (config.type === 'conventional+body' || config.type === 'subject+body') {
+				const result = await generateCommitMessage({
+					baseUrl,
+					apiKey,
+					model,
+					locale: config.locale,
+					diff: diffToUse,
+					completions: 1,
+					maxLength: config['max-length'],
+					type: config.type,
+					timeout,
+					headers: providerHeaders,
+				});
+				const title = result.messages[0];
+				const { description } = await generateCommitDescription({
+					baseUrl,
+					apiKey,
+					model,
+					locale: config.locale,
+					title,
+					diff: diffToUse,
+					timeout,
+					maxLength: config['max-length'],
+					headers: providerHeaders,
+				});
+				messages = [description.trim() ? `${title}\n\n${description.trim()}` : title];
+			} else {
+				const result = await generateCommitMessage({
+					baseUrl,
+					apiKey,
+					model,
+					locale: config.locale,
+					diff: diffToUse,
+					completions: config.generate,
+					maxLength: config['max-length'],
+					type: config.type,
+					timeout,
+					headers: providerHeaders,
+				});
+				messages = result.messages;
+			}
 		} finally {
 			s?.stop('Changes analyzed');
 		}

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -127,6 +127,7 @@ export default command(
 				options: [
 					{ value: 'plain', label: 'Plain - Simple format without structure' },
 					{ value: 'conventional', label: 'Conventional - Standard conventional commits' },
+					{ value: 'conventional+body', label: 'Conventional + body - Conventional commit subject and body' },
 					{ value: 'gitmoji', label: 'Gitmoji - Using emojis for commit types' },
 					{ value: 'subject+body', label: 'Subject + body - Git-style subject line and body' },
 				],

--- a/src/feature/providers/together.ts
+++ b/src/feature/providers/together.ts
@@ -14,7 +14,6 @@ export const TogetherProvider: ProviderDef = {
 			)
 			.map((m: any) => m.id),
 	defaultModels: [
-		'Qwen/Qwen3-Coder-Next-FP8',
 		'deepseek-ai/DeepSeek-V3.1',
 		'Qwen/Qwen3.5-9B',
 		'Qwen/Qwen3.5-397B-A17B',

--- a/src/utils/config-types.ts
+++ b/src/utils/config-types.ts
@@ -1,6 +1,12 @@
 import { KnownError } from './error.js';
 
-const commitTypes = ['plain', 'conventional', 'gitmoji', 'subject+body'] as const;
+const commitTypes = [
+	'plain',
+	'conventional',
+	'conventional+body',
+	'gitmoji',
+	'subject+body',
+] as const;
 
 export type CommitType = (typeof commitTypes)[number];
 

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -3,11 +3,33 @@ import type { CommitType } from './config-types.js';
 export const commitTypeFormats: Record<CommitType, string> = {
 	plain: '<commit message>',
 	conventional: '<type>[optional (<scope>)]: <commit message>\nThe commit message subject must start with a lowercase letter',
+	'conventional+body': '<type>[optional (<scope>)]: <commit message subject>\nThe commit message subject must start with a lowercase letter',
 	gitmoji: ':emoji: <commit message>',
 	'subject+body': '<commit message subject>',
 };
 const specifyCommitFormat = (type: CommitType) =>
 	`The output response must be in format:\n${commitTypeFormats[type]}`;
+
+const conventionalTypeDescriptions = {
+	docs: 'Documentation only changes',
+	style:
+		'Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)',
+	refactor: 'A code change that improves code structure without changing functionality (renaming, restructuring classes/methods, extracting functions, etc)',
+	perf: 'A code change that improves performance',
+	test: 'Adding missing tests or correcting existing tests',
+	build: 'Changes that affect the build system or external dependencies',
+	ci: 'Changes to our CI configuration files and scripts',
+	chore: "Other changes that don't modify src or test files",
+	revert: 'Reverts a previous commit',
+	feat: 'A new feature',
+	fix: 'A bug fix',
+};
+
+const conventionalTypePrompt = `Choose a type from the type-to-description JSON below that best describes the git diff. IMPORTANT: The type MUST be lowercase (e.g., "feat", not "Feat" or "FEAT"):\n${JSON.stringify(
+	conventionalTypeDescriptions,
+	null,
+	2
+)}`;
 
 const commitTypes: Record<CommitType, string> = {
 	plain: '',
@@ -20,24 +42,8 @@ const commitTypes: Record<CommitType, string> = {
 	 * Conventional Changelog:
 	 * https://github.com/conventional-changelog/conventional-changelog/blob/d0e5d5926c8addba74bc962553dd8bcfba90e228/packages/conventional-changelog-conventionalcommits/writer-opts.js#L182-L193
 	 */
-	conventional: `Choose a type from the type-to-description JSON below that best describes the git diff. IMPORTANT: The type MUST be lowercase (e.g., "feat", not "Feat" or "FEAT"):\n${JSON.stringify(
-		{
-			docs: 'Documentation only changes',
-			style:
-				'Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)',
-			refactor: 'A code change that improves code structure without changing functionality (renaming, restructuring classes/methods, extracting functions, etc)',
-			perf: 'A code change that improves performance',
-			test: 'Adding missing tests or correcting existing tests',
-			build: 'Changes that affect the build system or external dependencies',
-			ci: 'Changes to our CI configuration files and scripts',
-			chore: "Other changes that don't modify src or test files",
-			revert: 'Reverts a previous commit',
-			feat: 'A new feature',
-			fix: 'A bug fix',
-		},
-		null,
-		2
-	)}`,
+	conventional: conventionalTypePrompt,
+	'conventional+body': `${conventionalTypePrompt}\nOutput only the conventional commit subject line; the body is generated separately.`,
 
 	/**
 	 * References:

--- a/tests/specs/cli/commits.ts
+++ b/tests/specs/cli/commits.ts
@@ -313,6 +313,47 @@ export default testSuite(({ describe }) => {
 				await fixture.rm();
 			});
 
+			test('conventional+body generates commit with conventional subject and body', async () => {
+				const conventionalCommitPattern =
+					/(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test):\s/;
+				const { fixture, aicommits } = await createFixture({
+					...files,
+					'.aicommits': `${files['.aicommits']}\ntype=conventional+body`,
+				});
+				const git = await createGit(fixture.path);
+
+				await git('add', ['data.json']);
+
+				const committing = aicommits();
+
+				committing.stdout!.on('data', (buffer: Buffer) => {
+					const stdout = buffer.toString();
+					if (stdout.match('└')) {
+						committing.stdin!.write('y');
+						committing.stdin!.end();
+					}
+				});
+
+				await committing;
+
+				const statusAfter = await git('status', [
+					'--porcelain',
+					'--untracked-files=no',
+				]);
+				expect(statusAfter.stdout).toBe('');
+
+				const { stdout: fullMessage } = await git('log', [
+					'-n1',
+					'--pretty=format:%B',
+				]);
+				const [subjectLine] = fullMessage.trim().split('\n');
+				expect(subjectLine).toMatch(conventionalCommitPattern);
+				expect(fullMessage).toContain('\n');
+				expect(fullMessage.trim().split('\n').length).toBeGreaterThanOrEqual(2);
+
+				await fixture.rm();
+			});
+
 			test('Accepts --type flag, overriding config', async () => {
 				const conventionalCommitPattern =
 					/(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test):\s/;

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -72,6 +72,13 @@ export default testSuite(({ describe }) => {
 			});
 		});
 
+		await test('accepts type=conventional+body', async () => {
+			await aicommits(['config', 'set', 'OPENAI_API_KEY=abc']);
+			await aicommits(['config', 'set', 'type=conventional+body']);
+			const { stdout } = await aicommits(['config', 'get', 'type']);
+			expect(stdout).toBe('type=conventional+body');
+		});
+
 		await test('accepts type=subject+body', async () => {
 			await aicommits(['config', 'set', 'OPENAI_API_KEY=abc']);
 			await aicommits(['config', 'set', 'type=subject+body']);

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -5,7 +5,7 @@ Generate git commit messages using AI directly from VSCode's Git interface.
 ## Features
 
 - Generate commit messages with a single click from the Source Control panel
-- Support for plain, conventional, and gitmoji commit formats
+- Support for plain, conventional, conventional+body, gitmoji, and subject+body commit formats
 - Integrates seamlessly with VSCode's built-in Git extension
 - Preview messages before committing or auto-commit option
 
@@ -21,7 +21,9 @@ Generate git commit messages using AI directly from VSCode's Git interface.
 3. Click the sparkle icon in the toolbar or use the command palette:
    - `AI Commits: Generate Commit Message` - Plain format
    - `AI Commits: Generate Conventional Commit` - Conventional commits format
+   - `AI Commits: Generate Conventional+Body Commit` - Conventional commits format with a body
    - `AI Commits: Generate Gitmoji Commit` - Gitmoji format
+   - `AI Commits: Generate Subject+Body Commit` - Subject line with a body
 4. The generated message appears in the commit input box
 5. Review and commit!
 
@@ -30,14 +32,16 @@ Generate git commit messages using AI directly from VSCode's Git interface.
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `aicommits.path` | `aicommits` | Path to the aicommits CLI binary |
-| `aicommits.defaultType` | `plain` | Default commit message format (plain, conventional, gitmoji) |
+| `aicommits.defaultType` | `plain` | Default commit message format (plain, conventional, conventional+body, gitmoji, subject+body) |
 | `aicommits.autoCommit` | `false` | Auto-commit after generating (skips preview) |
 
 ## Commands
 
 - `aicommits.generate` - Generate plain commit message
 - `aicommits.generateConventional` - Generate conventional commit
+- `aicommits.generateConventionalBody` - Generate conventional commit with body
 - `aicommits.generateGitmoji` - Generate gitmoji commit
+- `aicommits.generateSubjectBody` - Generate subject and body commit
 - `aicommits.setup` - Setup AI provider (opens terminal)
 - `aicommits.selectModel` - Select AI model (opens terminal)
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -46,6 +46,11 @@
 				"icon": "$(checklist)"
 			},
 			{
+				"command": "aicommits.generateConventionalBody",
+				"title": "AI Commits: Generate Conventional+Body Commit",
+				"icon": "$(checklist)"
+			},
+			{
 				"command": "aicommits.generateGitmoji",
 				"title": "AI Commits: Generate Gitmoji Commit",
 				"icon": "$(symbol-enum)"
@@ -94,6 +99,7 @@
 					"enum": [
 						"plain",
 						"conventional",
+						"conventional+body",
 						"gitmoji",
 						"subject+body"
 					],

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -19,7 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
 		() => {
 			const config = vscode.workspace.getConfiguration('aicommits');
 			const defaultType = config.get<
-				'plain' | 'conventional' | 'gitmoji' | 'subject+body'
+				'plain' | 'conventional' | 'conventional+body' | 'gitmoji' | 'subject+body'
 			>('defaultType', 'plain');
 			return generateCommitMessage(defaultType);
 		},
@@ -28,6 +28,11 @@ export function activate(context: vscode.ExtensionContext) {
 	const generateConventionalCommand = vscode.commands.registerCommand(
 		'aicommits.generateConventional',
 		() => generateCommitMessage('conventional'),
+	);
+
+	const generateConventionalBodyCommand = vscode.commands.registerCommand(
+		'aicommits.generateConventionalBody',
+		() => generateCommitMessage('conventional+body'),
 	);
 
 	const generateGitmojiCommand = vscode.commands.registerCommand(
@@ -52,6 +57,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		generateCommand,
 		generateConventionalCommand,
+		generateConventionalBodyCommand,
 		generateGitmojiCommand,
 		generateSubjectBodyCommand,
 		setupCommand,
@@ -257,7 +263,7 @@ async function ensureCliInstalled(): Promise<boolean> {
 }
 
 async function generateCommitMessage(
-	type: 'plain' | 'conventional' | 'gitmoji' | 'subject+body',
+	type: 'plain' | 'conventional' | 'conventional+body' | 'gitmoji' | 'subject+body',
 ) {
 	if (!(await ensureCliInstalled())) {
 		return;


### PR DESCRIPTION
adds a `conventional+body` commit message format. 

CHANGES:-
- add `conventional+body` as a supported commit type
- reuse the existing subject/body generation flow for conventional commit subjects
- show the new option in CLI help, setup, README, and VS Code extension config
- add tests for config acceptance and CLI commit generation

<img width="719" height="485" alt="WindowsTerminal_8Ecjlj5iPM" src="https://github.com/user-attachments/assets/0cf3b7c3-a995-44fd-9728-99eba3f72472" />
<img width="660" height="157" alt="WindowsTerminal_5h5q534G7s" src="https://github.com/user-attachments/assets/ab1119c4-2c61-4f28-a1dd-8a4e0076c2e8" />
