### PR TITLE
fix: handle OpenAI-compatible 400 provider errors

### DIFF
--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -9,6 +9,19 @@ import { isHeadless } from './headless.js';
 const shouldLogDebug = () =>
 	Boolean(process.env.DEBUG || process.env.AICOMMITS_DEBUG) && !isHeadless();
 
+const getErrorStatusCode = (error: any) => error.status ?? error.statusCode;
+
+const isProviderRequestError = (error: any) => {
+	const statusCode = getErrorStatusCode(error);
+	return (
+		error.message?.includes('Provider returned error') ||
+		(error.name === 'AI_APICallError' &&
+			typeof statusCode === 'number' &&
+			statusCode >= 400 &&
+			statusCode < 500)
+	);
+};
+
 /**
  * Extracts the actual response from reasoning model outputs.
  * Reasoning models (like DeepSeek R1, QwQ, etc.) include their thought process
@@ -208,7 +221,9 @@ export const generateCommitMessage = async ({
 			);
 		}
 
-		if (errorAsAny.status === 429) {
+		const statusCode = getErrorStatusCode(errorAsAny);
+
+		if (statusCode === 429) {
 			const resetHeader = errorAsAny.headers?.get('x-ratelimit-reset');
 			let rateLimitMessage = 'Rate limit exceeded';
 			if (resetHeader) {
@@ -233,15 +248,9 @@ export const generateCommitMessage = async ({
 			throw new KnownError(rateLimitMessage);
 		}
 
-		if (errorAsAny.message?.includes('Provider returned error')) {
-			throw new KnownError(
-				`Provider failed to process your request. Try running the command again, or switch to a different model with \`aicommits model\`.`
-			);
-		}
-
 		const msg = typeof errorAsAny.message === 'string' ? errorAsAny.message.toLowerCase() : '';
 		if (
-			errorAsAny.status === 404 ||
+			statusCode === 404 ||
 			msg.includes('unable to access') ||
 			(msg.includes('model') &&
 				(msg.includes('not found') ||
@@ -252,6 +261,12 @@ export const generateCommitMessage = async ({
 			const err = new KnownError(`Model "${model}" is not available or has been deprecated.`);
 			(err as any).isModelDeprecated = true;
 			throw err;
+		}
+
+		if (isProviderRequestError(errorAsAny)) {
+			throw new KnownError(
+				`Provider failed to process your request. Try running the command again, or switch to a different model with \`aicommits model\`.`
+			);
 		}
 
 		throw errorAsAny;
@@ -367,7 +382,7 @@ export const generateCommitDescription = async ({
 				`Error connecting to ${errorAsAny.hostname} (${errorAsAny.syscall}). Are you connected to the internet?`
 			);
 		}
-		if (errorAsAny.message?.includes('Provider returned error')) {
+		if (isProviderRequestError(errorAsAny)) {
 			throw new KnownError(
 				`Provider failed to process your request. Try running the command again, or switch to a different model with \`aicommits model\`.`
 			);
@@ -460,7 +475,7 @@ Do not add thanks, explanations, or any text outside the commit message.`;
 			);
 		}
 
-		if (errorAsAny.message?.includes('Provider returned error')) {
+		if (isProviderRequestError(errorAsAny)) {
 			throw new KnownError(
 				`Provider failed to process your request. Try running the command again, or switch to a different model with \`aicommits model\`.`
 			);

--- a/tests/specs/openai/index.ts
+++ b/tests/specs/openai/index.ts
@@ -1,14 +1,75 @@
+import http from 'node:http';
 import { expect, testSuite } from 'manten';
 import {
 	generateCommitMessage,
 	generateCommitDescription,
 } from '../../../src/utils/openai.js';
+import { KnownError } from '../../../src/utils/error.js';
 import type { ValidConfig } from '../../../src/utils/config-types.js';
 import { getDiff } from '../../utils.js';
 
 const { OPENAI_API_KEY } = process.env;
 
+const withOpenAICompatibleErrorServer = async (
+	callback: (baseUrl: string) => Promise<void>
+) => {
+	const server = http.createServer((req, res) => {
+		req.resume();
+		res.writeHead(400, { 'content-type': 'application/json' });
+		res.end(
+			JSON.stringify({
+				error: {
+					message: 'model failed to process request',
+					type: 'invalid_request_error',
+				},
+			})
+		);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (!address || typeof address === 'string') {
+		server.close();
+		throw new Error('Unable to start test server');
+	}
+
+	try {
+		await callback(`http://127.0.0.1:${address.port}/v1`);
+	} finally {
+		server.close();
+	}
+};
+
 export default testSuite(({ describe }) => {
+	describe('provider error handling', async ({ test }) => {
+		await test('wraps OpenAI-compatible 400 responses as KnownError', async () => {
+			let thrown: unknown;
+
+			await withOpenAICompatibleErrorServer(async (baseUrl) => {
+				try {
+					await generateCommitMessage({
+						baseUrl,
+						apiKey: 'test-api-key',
+						model: 'qwen2.5-coder-7b-instruct',
+						locale: 'en',
+						diff: 'diff --git a/a.txt b/a.txt\n+hello',
+						completions: 1,
+						maxLength: 72,
+						type: 'conventional',
+						timeout: 5000,
+					});
+				} catch (error) {
+					thrown = error;
+				}
+			});
+
+			expect(thrown instanceof KnownError).toBe(true);
+			expect((thrown as Error).message).toMatch(
+				'Provider failed to process your request'
+			);
+		});
+	});
+
 	if (!OPENAI_API_KEY) {
 		console.warn(
 			'⚠️  process.env.OPENAI_API_KEY is necessary to run these tests. Skipping...'


### PR DESCRIPTION
## Summary

- Treat AI SDK `APICallError.statusCode` 4xx responses from OpenAI-compatible providers as handled provider failures.
- Preserve the existing rate-limit and unavailable-model handling by checking both `status` and `statusCode`.
- Add a keyless regression test with a local OpenAI-compatible server returning HTTP 400.

## Why

Related to #344. Local OpenAI-compatible providers can reject a request with HTTP 400, and AI SDK exposes that as `APICallError` with `statusCode`. That shape currently bypasses the existing `KnownError` handling unless the message is exactly `Provider returned error`, so aicommits prints a stack trace and asks the user to file a bug report.

This does not make a provider-rejected request succeed; it keeps that failure in the normal user-facing provider-error path.

## Validation

- `corepack pnpm@9.15.9 install --frozen-lockfile`
- Local HTTP 400 repro: before the patch it returned `APICallError`; after the patch it returns `KnownError` with the provider failure message.
- `corepack pnpm@9.15.9 type-check`
- `corepack pnpm@9.15.9 build` (same dependency circular warnings as baseline)
- `corepack pnpm@9.15.9 test` (`OPENAI_API_KEY` and `TOGETHER_API_KEY` network tests skipped as before)