### PR TITLE
feat: add git ai commit skill

### DIFF
--- a/docs/superpowers/plans/2026-06-25-git-ai-commit-skill.md
+++ b/docs/superpowers/plans/2026-06-25-git-ai-commit-skill.md
@@ -1,0 +1,364 @@
+# Git AI Commit Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and locally install a reusable `git-ai-commit` skill that helps Codex and Claude Code generate and optionally create AI-assisted Git commits.
+
+**Architecture:** Keep the repository copy at `skills/git-ai-commit` as the source of truth, then copy it to `~/.codex/skills/git-ai-commit` for local Codex discovery. The skill is instruction-driven: it prefers the existing `aicommits` CLI, then falls back to direct staged-diff analysis when the CLI is unavailable or blocked.
+
+**Tech Stack:** Codex skill format, Markdown, YAML metadata, Git CLI, existing `aicommits` CLI.
+
+---
+
+## File Structure
+
+- Create `skills/git-ai-commit/SKILL.md`: main cross-agent workflow, trigger frontmatter, safety rules, fallback generation rules, and verification behavior.
+- Create `skills/git-ai-commit/agents/openai.yaml`: Codex UI metadata for the skill.
+- Create `skills/git-ai-commit/references/claude-code.md`: Claude Code-specific usage notes and installation guidance.
+- Copy `skills/git-ai-commit` to `~/.codex/skills/git-ai-commit`: local install target for immediate Codex discovery.
+
+### Task 1: Create Repository Skill Source
+
+**Files:**
+- Create: `skills/git-ai-commit/SKILL.md`
+- Create: `skills/git-ai-commit/references/claude-code.md`
+
+- [ ] **Step 1: Create the skill directories**
+
+Run:
+
+```bash
+mkdir -p skills/git-ai-commit/references
+```
+
+Expected: command exits with status 0.
+
+- [ ] **Step 2: Write `SKILL.md`**
+
+Create `skills/git-ai-commit/SKILL.md` with:
+
+```markdown
+---
+name: git-ai-commit
+description: Generate and optionally create Git commits with AI-assisted commit messages. Use when the user asks Codex or Claude Code to generate a commit message, commit staged changes, use aicommits/aic, create an AI commit, review staged Git changes for a commit, or install/use a Git AI commit workflow. Prefer the aicommits CLI when available and configured; fall back to direct staged-diff analysis when needed.
+---
+
+# Git AI Commit
+
+Use this skill to generate a Git commit message from staged changes and, when explicitly authorized, create the commit.
+
+## Core Rules
+
+- Base commit messages on staged changes only unless the user explicitly asks you to stage files.
+- Prefer the existing `aicommits` or `aic` CLI when it is installed and configured.
+- Fall back to direct `git diff --cached` analysis when `aicommits` is unavailable, unconfigured, blocked by a non-interactive environment, rate-limited, or timed out.
+- Show the proposed commit message before committing unless the user explicitly requested a non-interactive commit.
+- Run `git commit` only when the user explicitly asks for a commit or approves the proposed message.
+- Do not stage untracked files, bypass hooks, amend commits, reset, rebase, or force-push unless the user explicitly requests that separate operation.
+- Leave unrelated unstaged changes alone.
+- Never include secrets, API keys, tokens, passwords, or private values in commit messages.
+
+## Workflow
+
+1. Confirm the current directory is inside a Git repository:
+
+   ```bash
+   git rev-parse --show-toplevel
+   ```
+
+2. Inspect the working tree:
+
+   ```bash
+   git status --short
+   ```
+
+3. Check for staged changes:
+
+   ```bash
+   git diff --cached --name-only
+   ```
+
+4. If no staged changes exist:
+   - If the user asked to commit all tracked changes, stage tracked updates with `git add --update`.
+   - If the user named specific files, stage only those files.
+   - If the user did not say what to stage, ask what should be staged before continuing.
+
+5. Generate the message with `aicommits` when possible:
+   - Use `aicommits` first, or `aic` if only the alias is available.
+   - Pass user-requested options through, such as `--type conventional`, `--type subject+body`, `--prompt`, `--exclude`, `--generate`, `--yes`, or `--no-verify`.
+   - Prefer capturing stdout in headless environments.
+   - Use `--clipboard` only when an interactive terminal and clipboard are useful.
+
+6. If CLI-backed generation fails for a recoverable reason, generate the message directly from:
+
+   ```bash
+   git diff --cached --diff-algorithm=minimal
+   ```
+
+7. Present the proposed message.
+
+8. If committing is authorized, run `git commit` with the exact message. For multi-line messages, pass the subject and body with separate `-m` flags:
+
+   ```bash
+   git commit -m "subject" -m "body"
+   ```
+
+9. After a successful commit, show:
+   - The new commit hash from `git rev-parse --short HEAD`.
+   - The final commit message.
+
+## CLI Preference Details
+
+Before relying on `aicommits`, check whether either command exists:
+
+```bash
+command -v aicommits
+command -v aic
+```
+
+If a command exists, prefer:
+
+```bash
+aicommits --type conventional
+```
+
+Adjust flags to match the user request and repository convention. Examples:
+
+```bash
+aicommits --type conventional --clipboard
+aicommits --type subject+body
+aicommits --prompt "Write the commit message in Chinese"
+aicommits --exclude pnpm-lock.yaml
+```
+
+If the command reports missing configuration, do not run interactive setup unless the user asks for setup. Use fallback generation instead.
+
+## Fallback Message Rules
+
+When generating without `aicommits`:
+
+- Use only staged diff content.
+- Write in present tense.
+- Describe what changed, not just which files changed.
+- Prefer a concise subject under 72 characters unless the repository uses a different limit.
+- Use Conventional Commits when requested or when recent commits clearly use it.
+- Preserve the requested language.
+- Use a body only when requested or when the changes need context that does not fit the subject.
+- Avoid vague subjects such as `update files`, `fix changes`, `misc updates`, or `work in progress`.
+
+Good fallback examples:
+
+```text
+feat: add staged diff chunking for large commits
+```
+
+```text
+fix(config): tolerate missing provider settings in headless mode
+```
+
+```text
+docs: document aicommits setup for custom endpoints
+```
+
+## Error Handling
+
+- Not a Git repository: explain that the current directory must be a Git repository.
+- No staged changes: ask what should be staged or suggest staging files.
+- `aicommits` missing: continue with fallback generation and mention that installing `aicommits` enables CLI-backed generation.
+- Provider configuration missing: use fallback generation unless the user specifically wants to configure `aicommits`.
+- Timeout or rate limit: use fallback generation or ask whether to retry if the user specifically wanted CLI generation.
+- Commit hook failure: report the hook failure and mention that `--no-verify` is available only if they want to bypass hooks.
+
+## Claude Code Notes
+
+For Claude Code-specific packaging and usage details, read `references/claude-code.md` only when the user asks about Claude Code installation or adaptation.
+```
+
+- [ ] **Step 3: Write Claude Code reference**
+
+Create `skills/git-ai-commit/references/claude-code.md` with:
+
+```markdown
+# Claude Code Notes
+
+Use the same workflow from `SKILL.md` in Claude Code. The important adaptation is tool naming and installation location, not commit behavior.
+
+## Usage
+
+Trigger this skill for requests such as:
+
+- "Use AI to write a commit message."
+- "Commit the staged changes."
+- "Use aicommits to commit this."
+- "Generate a conventional commit for these staged changes."
+
+## Installation Shape
+
+For Claude Code, keep the skill folder contents intact:
+
+```text
+git-ai-commit/
+  SKILL.md
+  references/
+    claude-code.md
+```
+
+If a Claude Code environment supports project-level skills, place the folder in that environment's skill discovery path. If it does not, copy the `SKILL.md` workflow into the relevant project instructions.
+
+## Behavior Notes
+
+- Prefer the `aicommits` CLI when available.
+- Fall back to direct staged-diff analysis when the CLI is missing or cannot run.
+- Do not commit without explicit user authorization.
+- Do not stage untracked files unless explicitly requested.
+- Keep generated commit messages based on `git diff --cached`.
+```
+
+- [ ] **Step 4: Review the files**
+
+Run:
+
+```bash
+sed -n '1,260p' skills/git-ai-commit/SKILL.md
+sed -n '1,220p' skills/git-ai-commit/references/claude-code.md
+```
+
+Expected: frontmatter contains only `name` and `description`; no placeholders are present.
+
+### Task 2: Add Codex Metadata
+
+**Files:**
+- Create: `skills/git-ai-commit/agents/openai.yaml`
+
+- [ ] **Step 1: Read metadata guidance**
+
+Run:
+
+```bash
+sed -n '1,220p' /Users/hanly/.codex/skills/.system/skill-creator/references/openai_yaml.md
+```
+
+Expected: output describes `display_name`, `short_description`, and `default_prompt`.
+
+- [ ] **Step 2: Create metadata directory**
+
+Run:
+
+```bash
+mkdir -p skills/git-ai-commit/agents
+```
+
+Expected: command exits with status 0.
+
+- [ ] **Step 3: Write `openai.yaml`**
+
+Create `skills/git-ai-commit/agents/openai.yaml` with deterministic metadata matching `SKILL.md`:
+
+```yaml
+display_name: Git AI Commit
+short_description: Generate Git commit messages from staged changes.
+default_prompt: Generate an AI-assisted Git commit message for the staged changes, then ask before committing unless I explicitly authorize the commit.
+```
+
+- [ ] **Step 4: Review metadata**
+
+Run:
+
+```bash
+sed -n '1,120p' skills/git-ai-commit/agents/openai.yaml
+```
+
+Expected: YAML has exactly the three intended interface fields.
+
+### Task 3: Install Local Codex Copy
+
+**Files:**
+- Copy: `skills/git-ai-commit/` to `/Users/hanly/.codex/skills/git-ai-commit/`
+
+- [ ] **Step 1: Remove stale local copy if present**
+
+Run:
+
+```bash
+rm -rf /Users/hanly/.codex/skills/git-ai-commit
+```
+
+Expected: command exits with status 0. This removes only the generated local install copy.
+
+- [ ] **Step 2: Copy repository skill to Codex skills**
+
+Run:
+
+```bash
+cp -R skills/git-ai-commit /Users/hanly/.codex/skills/git-ai-commit
+```
+
+Expected: command exits with status 0.
+
+- [ ] **Step 3: Compare source and installed copy**
+
+Run:
+
+```bash
+diff -ru skills/git-ai-commit /Users/hanly/.codex/skills/git-ai-commit
+```
+
+Expected: no output and exit status 0.
+
+### Task 4: Validate And Commit Skill
+
+**Files:**
+- Validate: `skills/git-ai-commit/SKILL.md`
+- Validate: `skills/git-ai-commit/agents/openai.yaml`
+- Validate: `/Users/hanly/.codex/skills/git-ai-commit`
+
+- [ ] **Step 1: Locate validation script**
+
+Run:
+
+```bash
+find /Users/hanly/.codex/skills/.system/skill-creator -name quick_validate.py -print
+```
+
+Expected: output includes the path to `quick_validate.py`.
+
+- [ ] **Step 2: Validate repository skill**
+
+Run:
+
+```bash
+/Users/hanly/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/git-ai-commit
+```
+
+Expected: validation passes.
+
+- [ ] **Step 3: Validate installed skill**
+
+Run:
+
+```bash
+/Users/hanly/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/hanly/.codex/skills/git-ai-commit
+```
+
+Expected: validation passes.
+
+- [ ] **Step 4: Check repository status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intended skill files and the plan file are modified or untracked.
+
+- [ ] **Step 5: Commit implementation**
+
+Run:
+
+```bash
+git add skills/git-ai-commit docs/superpowers/plans/2026-06-25-git-ai-commit-skill.md
+git commit -m "feat: add git ai commit skill"
+```
+
+Expected: commit succeeds.

--- a/docs/superpowers/specs/2026-06-25-git-ai-commit-skill-design.md
+++ b/docs/superpowers/specs/2026-06-25-git-ai-commit-skill-design.md
@@ -1,0 +1,126 @@
+# Git AI Commit Skill Design
+
+## Goal
+
+Create a reusable `git-ai-commit` skill based on this `aicommits` project. The skill should help Codex and Claude Code generate and optionally create Git commits with AI-assisted commit messages.
+
+The skill should prefer the `aicommits` CLI when it is available and configured, then fall back to direct model-based commit message generation from `git diff --cached` when the CLI cannot be used.
+
+## Users And Triggers
+
+The skill should trigger when a user asks an agent to:
+
+- Generate an AI commit message.
+- Commit staged changes.
+- Use `aicommits`, `aic`, or AI commit tooling.
+- Review staged Git changes and write a commit.
+
+The initial implementation targets Codex first, while keeping the workflow and references usable for Claude Code.
+
+## Placement
+
+Keep a source copy in this repository:
+
+```text
+skills/git-ai-commit/
+```
+
+Install a copy for local Codex discovery:
+
+```text
+~/.codex/skills/git-ai-commit/
+```
+
+The repository copy is the editable source of truth. The local Codex copy should match it after implementation.
+
+## Skill Structure
+
+```text
+skills/
+  git-ai-commit/
+    SKILL.md
+    agents/
+      openai.yaml
+    references/
+      claude-code.md
+```
+
+`SKILL.md` contains the core cross-agent workflow.
+
+`agents/openai.yaml` contains Codex UI metadata generated from the skill.
+
+`references/claude-code.md` documents Claude Code-specific usage notes without duplicating the main workflow.
+
+No scripts are required for the first version. The skill delegates deterministic behavior to the existing `aicommits` CLI and uses normal Git commands for fallback.
+
+## Workflow
+
+1. Confirm the current directory is inside a Git repository with `git rev-parse --show-toplevel`.
+2. Inspect current changes with `git status --short`.
+3. Determine whether staged changes exist with `git diff --cached --name-only`.
+4. If no staged changes exist:
+   - If the user explicitly asked to stage tracked changes or commit all relevant work, stage only the requested files or tracked updates.
+   - Otherwise, ask the user what should be staged.
+5. Generate the commit message:
+   - Prefer `aicommits` or `aic` when available.
+   - Use `aicommits --clipboard` in interactive environments when copying is useful.
+   - Use headless command execution when stdout capture is needed.
+   - Pass format flags such as `--type conventional`, `--type subject+body`, `--prompt`, `--exclude`, `--no-verify`, or `--generate` when requested by the user.
+6. If `aicommits` is missing, unconfigured, non-interactive in a way that blocks setup, or fails for a recoverable reason, fall back to reading `git diff --cached` and generating a commit message directly.
+7. Before committing, show the proposed commit message unless the user explicitly requested a non-interactive commit.
+8. Run `git commit` only when the user explicitly asks the agent to commit or has already authorized committing.
+9. After committing, show the resulting commit hash and final commit message.
+
+## Fallback Message Rules
+
+When the agent generates the commit message without `aicommits`, it should:
+
+- Base the message only on staged changes.
+- Prefer present tense.
+- Be specific about behavior or files changed.
+- Avoid vague messages such as `update files` or `fix changes`.
+- Preserve the user's requested format and language.
+- Use Conventional Commits when requested or when the repository clearly follows that pattern.
+- Use a body only when requested or when the staged changes need more context.
+
+## Safety Rules
+
+The skill should avoid surprising repository mutations:
+
+- Do not stage untracked files unless the user explicitly requests them.
+- Do not run `git commit` unless the user explicitly asks for a commit or gives approval after seeing the message.
+- Do not bypass hooks with `--no-verify` unless requested.
+- Do not amend, reset, rebase, or force-push as part of this skill.
+- Do not include secrets or sensitive values in commit messages.
+- If the working tree has unrelated unstaged changes, leave them alone.
+
+## Error Handling
+
+The skill should handle these common cases:
+
+- Not in a Git repository: explain that the current directory must be a Git repository.
+- No staged changes: ask what should be staged or suggest staging files.
+- `aicommits` missing: use fallback generation and mention that installing `aicommits` enables CLI-backed generation.
+- Provider configuration missing: use fallback generation unless the user specifically wants to configure `aicommits`.
+- Provider timeout or rate limit: use fallback generation or ask whether to retry.
+- Commit hook failure: report the hook failure and mention `--no-verify` only as an explicit follow-up option.
+
+## Validation
+
+Implementation is complete when:
+
+- The repository skill exists at `skills/git-ai-commit`.
+- The local Codex copy exists at `~/.codex/skills/git-ai-commit`.
+- `SKILL.md` has valid frontmatter with only `name` and `description`.
+- `agents/openai.yaml` matches the skill.
+- `references/claude-code.md` exists and does not duplicate the full skill body.
+- The skill passes `quick_validate.py`.
+- The copied local skill matches the repository source.
+
+## Out Of Scope
+
+- Publishing to a marketplace.
+- Creating a Claude Code plugin package.
+- Changing the `aicommits` CLI implementation.
+- Adding new commit-generation features to `aicommits`.
+- Automatically installing Node packages or global CLIs.

--- a/skills/git-ai-commit/SKILL.md
+++ b/skills/git-ai-commit/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: git-ai-commit
+description: Generate and optionally create Git commits with AI-assisted commit messages. Use when the user asks Codex or Claude Code to generate a commit message, commit staged changes, use aicommits/aic, create an AI commit, review staged Git changes for a commit, or install/use a Git AI commit workflow. Prefer the aicommits CLI when available and configured; fall back to direct staged-diff analysis when needed.
+---
+
+# Git AI Commit
+
+Use this skill to generate a Git commit message from staged changes and, when explicitly authorized, create the commit.
+
+## Core Rules
+
+- Base commit messages on staged changes only unless the user explicitly asks you to stage files.
+- Prefer the existing `aicommits` or `aic` CLI when it is installed and configured.
+- Use `aicommits` for message generation only unless the user has already authorized a commit.
+- Fall back to direct `git diff --cached` analysis when `aicommits` is unavailable, unconfigured, blocked by a non-interactive environment, rate-limited, or timed out.
+- Show the proposed commit message before committing unless the user explicitly requested a non-interactive commit.
+- Run `git commit` only when the user explicitly asks for a commit or approves the proposed message.
+- Do not stage untracked files, bypass hooks, amend commits, reset, rebase, or force-push unless the user explicitly requests that separate operation.
+- Leave unrelated unstaged changes alone.
+- Never include secrets, API keys, tokens, passwords, or private values in commit messages.
+
+## Workflow
+
+1. Confirm the current directory is inside a Git repository:
+
+   ```bash
+   git rev-parse --show-toplevel
+   ```
+
+2. Inspect the working tree:
+
+   ```bash
+   git status --short
+   ```
+
+3. Check for staged changes:
+
+   ```bash
+   git diff --cached --name-only
+   ```
+
+4. If no staged changes exist:
+   - If the user asked to commit all tracked changes, stage tracked updates with `git add --update`.
+   - If the user named specific files, stage only those files.
+   - If the user did not say what to stage, ask what should be staged before continuing.
+
+5. Generate the message with `aicommits` when possible:
+   - Check for `aicommits` first, then `aic`.
+   - Pass user-requested options through, such as `--type conventional`, `--type subject+body`, `--prompt`, `--exclude`, or `--generate`.
+   - In headless command execution, capture stdout from `aicommits`; this mode prints the generated message and does not commit.
+   - In an interactive terminal, prefer `--clipboard` when you only need the generated message.
+   - Do not pass `--yes` or run an interactive commit flow unless the user already authorized committing.
+
+6. If CLI-backed generation fails for a recoverable reason, generate the message directly from:
+
+   ```bash
+   git diff --cached --diff-algorithm=minimal
+   ```
+
+7. Present the proposed message.
+
+8. If committing is authorized, run `git commit` with the exact message. For multi-line messages, pass the subject and body with separate `-m` flags:
+
+   ```bash
+   git commit -m "subject" -m "body"
+   ```
+
+9. After a successful commit, show:
+   - The new commit hash from `git rev-parse --short HEAD`.
+   - The final commit message.
+
+## CLI Preference Details
+
+Before relying on `aicommits`, check whether either command exists:
+
+```bash
+command -v aicommits
+command -v aic
+```
+
+If a command exists, use the repository's requested or inferred format. Examples:
+
+```bash
+aicommits --type conventional
+aicommits --type subject+body
+aicommits --prompt "Write the commit message in Chinese"
+aicommits --exclude pnpm-lock.yaml
+```
+
+If the command reports missing configuration, do not run interactive setup unless the user asks for setup. Use fallback generation instead.
+
+## Fallback Message Rules
+
+When generating without `aicommits`:
+
+- Use only staged diff content.
+- Write in present tense.
+- Describe what changed, not just which files changed.
+- Prefer a concise subject under 72 characters unless the repository uses a different limit.
+- Use Conventional Commits when requested or when recent commits clearly use it.
+- Preserve the requested language.
+- Use a body only when requested or when the changes need context that does not fit the subject.
+- Avoid vague subjects such as `update files`, `fix changes`, `misc updates`, or `work in progress`.
+
+Good fallback examples:
+
+```text
+feat: add staged diff chunking for large commits
+```
+
+```text
+fix(config): tolerate missing provider settings in headless mode
+```
+
+```text
+docs: document aicommits setup for custom endpoints
+```
+
+## Error Handling
+
+- Not a Git repository: explain that the current directory must be a Git repository.
+- No staged changes: ask what should be staged or suggest staging files.
+- `aicommits` missing: continue with fallback generation and mention that installing `aicommits` enables CLI-backed generation.
+- Provider configuration missing: use fallback generation unless the user specifically wants to configure `aicommits`.
+- Timeout or rate limit: use fallback generation or ask whether to retry if the user specifically wanted CLI generation.
+- Commit hook failure: report the hook failure and mention that `--no-verify` is available only if they want to bypass hooks.
+
+## Claude Code Notes
+
+For Claude Code-specific packaging and usage details, read `references/claude-code.md` only when the user asks about Claude Code installation or adaptation.

--- a/skills/git-ai-commit/agents/openai.yaml
+++ b/skills/git-ai-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git AI Commit"
+  short_description: "Generate Git commit messages from staged changes."
+  default_prompt: "Use $git-ai-commit to generate an AI-assisted Git commit message for the staged changes, then ask before committing unless I explicitly authorize the commit."

--- a/skills/git-ai-commit/references/claude-code.md
+++ b/skills/git-ai-commit/references/claude-code.md
@@ -1,0 +1,33 @@
+# Claude Code Notes
+
+Use the same workflow from `SKILL.md` in Claude Code. The important adaptation is tool naming and installation location, not commit behavior.
+
+## Usage
+
+Trigger this skill for requests such as:
+
+- "Use AI to write a commit message."
+- "Commit the staged changes."
+- "Use aicommits to commit this."
+- "Generate a conventional commit for these staged changes."
+
+## Installation Shape
+
+For Claude Code, keep the skill folder contents intact:
+
+```text
+git-ai-commit/
+  SKILL.md
+  references/
+    claude-code.md
+```
+
+If a Claude Code environment supports project-level skills, place the folder in that environment's skill discovery path. If it does not, copy the `SKILL.md` workflow into the relevant project instructions.
+
+## Behavior Notes
+
+- Prefer the `aicommits` CLI when available.
+- Fall back to direct staged-diff analysis when the CLI is missing or cannot run.
+- Do not commit without explicit user authorization.
+- Do not stage untracked files unless explicitly requested.
+- Keep generated commit messages based on `git diff --cached`.


### PR DESCRIPTION
## Summary
- Add a reusable Codex/Claude Code skill for AI-assisted Git commits.
- Prefer the existing aicommits CLI and fall back to staged diff analysis when needed.
- Include Codex UI metadata, Claude Code notes, and local skill installation guidance.

## Verification
- pnpm build
- pnpm test
- python3 /Users/hanly/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/git-ai-commit
- python3 /Users/hanly/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/hanly/.codex/skills/git-ai-commit
- diff -ru skills/git-ai-commit /Users/hanly/.codex/skills/git-ai-commit