### PR TITLE
feat(providers): add Requesty provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This will guide you through:
   - **Groq** - Get your API key from [Groq Console](https://console.groq.com/keys)
   - **xAI** - Get your API key from [xAI Console](https://console.x.ai/)
   - **OpenRouter** - Get your API key from [OpenRouter](https://openrouter.ai/keys)
+  - **Requesty** - Get your API key from [Requesty](https://app.requesty.ai/api-keys)
   - **Ollama** (local) - Run AI models locally with [Ollama](https://ollama.ai)
   - **LM Studio** (local) - No API key required. Runs on your computer via [LM Studio](https://lmstudio.ai/)
   - **Custom OpenAI-compatible endpoint** - Use any service that implements the OpenAI API
@@ -314,7 +315,7 @@ Model to use for OpenAI-compatible providers.
 
 #### provider
 
-The selected AI provider. Set automatically during `aicommits setup`. Valid values: `openai`, `togetherai`, `groq`, `xai`, `openrouter`, `ollama`, `lmstudio`, `custom`.
+The selected AI provider. Set automatically during `aicommits setup`. Valid values: `openai`, `togetherai`, `groq`, `xai`, `openrouter`, `requesty`, `ollama`, `lmstudio`, `custom`.
 
 #### locale
 

--- a/src/feature/providers/providers-data.ts
+++ b/src/feature/providers/providers-data.ts
@@ -3,6 +3,7 @@ import { OpenAiProvider } from './openai.js';
 import { OllamaProvider } from './ollama.js';
 import { OpenAiCustom } from './openaiCustom.js';
 import { OpenRouterProvider } from './openrouter.js';
+import { RequestyProvider } from './requesty.js';
 import { LMStudioProvider } from './lmstudio.js';
 import { GroqProvider } from './groq.js';
 import { XAiProvider } from './xai.js';
@@ -12,8 +13,9 @@ export const providers = [
 	OpenAiProvider,
 	GroqProvider,
 	XAiProvider,
+	OpenRouterProvider,
+	RequestyProvider,
 	OllamaProvider,
 	LMStudioProvider,
-	OpenRouterProvider,
 	OpenAiCustom,
 ];

--- a/src/feature/providers/requesty.ts
+++ b/src/feature/providers/requesty.ts
@@ -1,0 +1,17 @@
+import { ProviderDef } from './base.js';
+
+export const RequestyProvider: ProviderDef = {
+	name: 'requesty',
+	displayName: 'Requesty',
+	baseUrl: 'https://router.requesty.ai/v1',
+	modelsFilter: (models) =>
+		models
+			.filter((m: any) => m.id && (!m.type || m.type === 'chat'))
+			.map((m: any) => m.id),
+	defaultModels: ['openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-5'],
+	requiresApiKey: true,
+	headers: {
+		'HTTP-Referer': 'https://github.com/nutlope/aicommits',
+		'X-Title': 'aicommits',
+	},
+};


### PR DESCRIPTION
## What

Adds Requesty as a dedicated, named provider, mirroring the existing OpenRouter provider (`src/feature/providers/openrouter.ts`) as closely as possible.

Requesty is an OpenAI-compatible LLM gateway/router. It exposes the standard OpenAI Chat Completions and `/v1/models` endpoints, uses `Authorization: Bearer <key>`, and uses the same `provider/model` naming convention as OpenRouter (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`).

## Changes

- `src/feature/providers/requesty.ts` (new): `ProviderDef` with
  - `baseUrl: https://router.requesty.ai/v1`
  - `provider/model` naming
  - `modelsFilter` identical to OpenRouter's (id + chat filter)
  - optional `HTTP-Referer` / `X-Title` analytics headers (same names OpenRouter uses)
  - `requiresApiKey: true`
- `src/feature/providers/providers-data.ts`: register `RequestyProvider` in the provider list.
- `README.md`: add Requesty to the supported-providers list and to the valid `provider` config values.

The provider is wired on the generic OpenAI-compatible path, so no SDK-specific routing objects are needed. The API key is read from the existing `OPENAI_API_KEY` config slot, same as the other hosted providers.

## Testing

- `tsc --noEmit`: passes (0 errors).
- `pkgroll` build: succeeds.
- Test suite (`tsx tests`): 19 passed (API-key-gated tests skipped, as without credentials).
- Live-tested the endpoint directly with a real Requesty key using the provider's exact base URL, `provider/model` naming, and the `HTTP-Referer`/`X-Title` headers:
  - `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` returned the expected marker response.
  - `GET https://router.requesty.ai/v1/models` returned HTTP 200 with 605 models in OpenAI shape; the `modelsFilter` correctly yields the model ids (including the `openai/gpt-4o-mini` default).

## Docs

- https://requesty.ai
- https://docs.requesty.ai
- https://app.requesty.ai/api-keys
- https://app.requesty.ai/router/list

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
