### PR TITLE
feat: support provider-specific request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,20 @@ Custom OpenAI-compatible API endpoint URL.
 
 Model to use for OpenAI-compatible providers.
 
+#### PROVIDER_OPTIONS
+
+JSON object with provider-specific request options. This is useful for custom
+OpenAI-compatible endpoints or models that require fields not exposed as a
+first-class aicommits setting. The top-level keys must match the AI SDK provider
+name. Custom OpenAI-compatible endpoints use `custom`.
+
+```sh
+aicommits config set 'PROVIDER_OPTIONS={"custom":{"customOption":"value"}}'
+```
+
+Configured options are merged with aicommits defaults. Matching user values
+override defaults while other default options remain unchanged.
+
 #### provider
 
 The selected AI provider. Set automatically during `aicommits setup`. Valid values: `openai`, `togetherai`, `groq`, `xai`, `openrouter`, `ollama`, `lmstudio`, `custom`.

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -43,7 +43,9 @@ export default command(
 						const value = config[key as keyof typeof config];
 						const displayValue = sensitiveKeys.includes(key)
 							? `${String(value).substring(0, 4)}****`
-							: String(value);
+							: typeof value === 'object'
+								? JSON.stringify(value)
+								: String(value);
 						console.log(`${key}=${displayValue}`);
 					}
 				}
@@ -52,7 +54,18 @@ export default command(
 
 			if (mode === 'set') {
 				await setConfigs(
-					keyValues.map((keyValue) => keyValue.split('=') as [string, string])
+					keyValues.map((keyValue) => {
+						const separator = keyValue.indexOf('=');
+						if (separator === -1) {
+							throw new KnownError(
+								`Invalid config value: ${keyValue}. Expected KEY=value.`
+							);
+						}
+						return [
+							keyValue.slice(0, separator),
+							keyValue.slice(separator + 1),
+						] as [string, string];
+					})
 				);
 				return;
 			}

--- a/src/feature/providers/base.ts
+++ b/src/feature/providers/base.ts
@@ -2,12 +2,14 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { createTogetherAI } from '@ai-sdk/togetherai';
 import type {
-	JSONValue,
 	LanguageModel,
 	LanguageModelCallOptions,
 } from 'ai';
 import { fetchModels } from '../models.js';
-import type { ValidConfig } from '../../utils/config-types.js';
+import type {
+	ProviderOptions,
+	ValidConfig,
+} from '../../utils/config-types.js';
 
 const isLoopbackUrl = (baseUrl: string): boolean => {
 	try {
@@ -39,7 +41,7 @@ export type ProviderDef = {
 export type GenerationCallOptions = {
 	maxOutputTokens?: LanguageModelCallOptions['maxOutputTokens'];
 	reasoning?: LanguageModelCallOptions['reasoning'];
-	providerOptions?: Record<string, Record<string, JSONValue>>;
+	providerOptions?: ProviderOptions;
 };
 
 export type GenerationModel = {
@@ -207,13 +209,41 @@ export class Provider {
 			agenticGeneration && (agenticGeneration.supports?.(model) ?? true)
 		);
 
+		const callOptions = supportsAgenticGeneration
+			? agenticGeneration?.callOptions?.(model) ?? {}
+			: {};
+		const providerOptions = this.mergeProviderOptions(
+			callOptions.providerOptions
+		);
+
 		return {
 			mode: supportsAgenticGeneration ? 'agentic' : 'fallback',
 			isLocal: this.isLocal(),
-			callOptions: supportsAgenticGeneration
-				? agenticGeneration?.callOptions?.(model) ?? {}
-				: {},
+			callOptions:
+				Object.keys(providerOptions).length > 0
+					? { ...callOptions, providerOptions }
+					: callOptions,
 		};
+	}
+
+	private mergeProviderOptions(
+		defaultOptions: ProviderOptions | undefined
+	): ProviderOptions {
+		const configuredOptions = this.config.PROVIDER_OPTIONS ?? {};
+		const providerNames = new Set([
+			...Object.keys(defaultOptions ?? {}),
+			...Object.keys(configuredOptions),
+		]);
+
+		return Object.fromEntries(
+			[...providerNames].map((providerName) => [
+				providerName,
+				{
+					...defaultOptions?.[providerName],
+					...configuredOptions[providerName],
+				},
+			])
+		) as ProviderOptions;
 	}
 
 	validateConfig(): { valid: boolean; errors: string[] } {

--- a/src/utils/config-runtime.ts
+++ b/src/utils/config-runtime.ts
@@ -40,6 +40,14 @@ const detectProvider = (
 
 const getConfigPath = () => path.join(os.homedir(), '.aicommits');
 
+const parseConfigValue = (key: ConfigKeys, value: unknown) => {
+	if (key === 'PROVIDER_OPTIONS') {
+		return configParsers.PROVIDER_OPTIONS(value);
+	}
+
+	return configParsers[key](value as string | undefined);
+};
+
 const readConfigFile = async (): Promise<RawConfig> => {
 	const configExists = await fileExists(getConfigPath());
 	if (!configExists) {
@@ -66,15 +74,14 @@ export const getConfig = async (
 	const effectiveEnvConfig = envConfig ?? {};
 
 	for (const key of Object.keys(configParsers) as ConfigKeys[]) {
-		const parser = configParsers[key];
 		const value = cliConfig?.[key] ?? effectiveEnvConfig?.[key] ?? config[key];
 
 		if (suppressErrors) {
 			try {
-				parsedConfig[key] = parser(value);
+				parsedConfig[key] = parseConfigValue(key, value);
 			} catch {}
 		} else {
-			parsedConfig[key] = parser(value);
+			parsedConfig[key] = parseConfigValue(key, value);
 		}
 	}
 

--- a/src/utils/config-types.ts
+++ b/src/utils/config-types.ts
@@ -1,4 +1,5 @@
 import { KnownError } from './error.js';
+import type { JSONValue } from 'ai';
 
 const commitTypes = [
 	'plain',
@@ -36,6 +37,67 @@ const parseAssert = (name: string, condition: boolean, message: string) => {
 	}
 };
 
+export type ProviderOptions = Record<string, Record<string, JSONValue>>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isJsonValue = (value: unknown): value is JSONValue => {
+	if (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean'
+	) {
+		return true;
+	}
+
+	if (Array.isArray(value)) {
+		return value.every(isJsonValue);
+	}
+
+	return isRecord(value) && Object.values(value).every(isJsonValue);
+};
+
+const parseProviderOptions = (value?: unknown): ProviderOptions => {
+	if (value === undefined || value === '') {
+		return {};
+	}
+
+	let parsed: unknown = value;
+	if (typeof value === 'string') {
+		try {
+			parsed = JSON.parse(value);
+		} catch {
+			throw new KnownError(
+				'Invalid config property PROVIDER_OPTIONS: Must be valid JSON.'
+			);
+		}
+	}
+
+	parseAssert(
+		'PROVIDER_OPTIONS',
+		isRecord(parsed),
+		'Must be an object keyed by provider name.'
+	);
+	const parsedOptions = parsed as Record<string, unknown>;
+
+	for (const [providerName, options] of Object.entries(parsedOptions)) {
+		parseAssert(
+			'PROVIDER_OPTIONS',
+			isRecord(options),
+			`Provider "${providerName}" options must be an object.`
+		);
+		parseAssert(
+			'PROVIDER_OPTIONS',
+			isJsonValue(options),
+			`Provider "${providerName}" options must contain JSON values.`
+		);
+	}
+
+	return parsedOptions as ProviderOptions;
+};
+
 const configParsers = {
 	OPENAI_API_KEY(key?: string) {
 		return key;
@@ -45,6 +107,9 @@ const configParsers = {
 	},
 	OPENAI_MODEL(key?: string) {
 		return key || '';
+	},
+	PROVIDER_OPTIONS(value?: unknown) {
+		return parseProviderOptions(value);
 	},
 	locale(locale?: string) {
 		if (!locale) {
@@ -117,7 +182,7 @@ const configParsers = {
 type ConfigKeys = keyof typeof configParsers;
 
 type RawConfig = {
-	[key in ConfigKeys]?: string;
+	[key in ConfigKeys]?: unknown;
 };
 
 export type ValidConfig = {

--- a/tests/specs/cli/headless.ts
+++ b/tests/specs/cli/headless.ts
@@ -55,6 +55,7 @@ export default testSuite(({ describe }) => {
 					'OPENAI_API_KEY=test-key',
 					`OPENAI_BASE_URL=${agentServer.baseUrl}`,
 					'OPENAI_MODEL=test-model',
+					'PROVIDER_OPTIONS={"custom":{"customOption":"value"}}',
 				].join('\n'),
 				'data.json': '{"agentic":true}\n',
 			});
@@ -71,6 +72,7 @@ export default testSuite(({ describe }) => {
 				expect(stdout).toBe('feat: add test data');
 				expect(agentServer.requests.length).toBe(1);
 				expect(agentServer.requests[0]).toMatch('agentic');
+				expect(JSON.parse(agentServer.requests[0]).customOption).toBe('value');
 			} finally {
 				await agentServer.close();
 				await fixture.rm();

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -40,6 +40,32 @@ export default testSuite(({ describe }) => {
 			expect(stdout).toBe('OPENAI_API_KEY=abc****');
 		});
 
+		await test('sets and displays provider options', async () => {
+			await aicommits([
+				'config',
+				'set',
+				'PROVIDER_OPTIONS={"custom":{"customOption":"value=1"}}',
+			]);
+
+			const { stdout } = await aicommits([
+				'config',
+				'get',
+				'PROVIDER_OPTIONS',
+			]);
+			expect(stdout).toBe(
+				'PROVIDER_OPTIONS={"custom":{"customOption":"value=1"}}'
+			);
+		});
+
+		test('rejects invalid provider options JSON', async () => {
+			const { stderr } = await aicommits(
+				['config', 'set', 'PROVIDER_OPTIONS={invalid'],
+				{ reject: false }
+			);
+
+			expect(stderr).toMatch('PROVIDER_OPTIONS: Must be valid JSON');
+		});
+
 		await test('reading unknown config', async () => {
 			await fs.appendFile(configPath, 'UNKNOWN=1');
 

--- a/tests/specs/providers.ts
+++ b/tests/specs/providers.ts
@@ -110,5 +110,32 @@ export default testSuite(({ describe }) => {
 				createProvider('lmstudio').getGenerationPolicy('local-tool-model')
 			).toMatchObject({ mode: 'agentic', isLocal: true });
 		});
+
+		test('merges configured provider options with the generation policy', () => {
+			expect(
+				createProvider('openai', {
+					PROVIDER_OPTIONS: { openai: { store: true } },
+				}).getGenerationPolicy('gpt-5-mini')
+			).toMatchObject({
+				callOptions: {
+					providerOptions: {
+						openai: { reasoningEffort: 'minimal', store: true },
+					},
+				},
+			});
+		});
+
+		test('passes configured provider options to custom providers', () => {
+			expect(
+				createProvider('custom', {
+					PROVIDER_OPTIONS: { custom: { customOption: 'value' } },
+				}).getGenerationPolicy('custom-model')
+			).toMatchObject({
+				mode: 'fallback',
+				callOptions: {
+					providerOptions: { custom: { customOption: 'value' } },
+				},
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds a `PROVIDER_OPTIONS` configuration property for passing provider-specific request fields through the AI SDK.

## Changes

- Parses and validates a JSON object keyed by provider name.
- Merges configured options with built-in generation policy options without discarding unrelated defaults.
- Preserves values containing `=` when using `aicommits config set`.
- Verifies end-to-end forwarding of an unknown option to a custom OpenAI-compatible endpoint.
- Documents the configuration format and adds coverage for parsing, merging, and request forwarding.

## Impact

Custom OpenAI-compatible endpoints can now receive provider-specific request fields without changes to aicommits or the AI SDK.

## Validation

- `pnpm type-check`
- `pnpm build`
- `pnpm test` (72 passed)

Closes #357