### PR TITLE
feat: add authenticated Codex and Claude CLI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ This will guide you through:
   - **Codex CLI** - Use your existing Codex CLI login and subscription. No API key required.
   - **Claude CLI** - Use your existing Claude Code login and subscription. No API key required.
 
+  ### Codex CLI and Claude CLI prerequisites
+
+  The selected CLI must be installed, authenticated, and available on your shell's `PATH` before running `aicommits`. Verify the command from the same terminal where you run `aicommits`:
+
+  ```sh
+  command -v codex
+  codex login status
+
+  command -v claude
+  ```
+
+  If a desktop app bundles the CLI but `command -v` cannot find it, add the app's CLI directory to your `PATH` or create a symlink in a directory already on your `PATH`.
+
   Together AI, OpenAI, xAI, and LM Studio models use the agentic generation
   flow. Tested Together models without compatible tool calls use the one-shot
   path; OpenAI, xAI, and LM Studio fall back when an endpoint rejects tools.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This will guide you through:
   - **Ollama** (local) - Run AI models locally with [Ollama](https://ollama.ai)
   - **LM Studio** (local) - No API key required. Runs on your computer via [LM Studio](https://lmstudio.ai/)
   - **Custom OpenAI-compatible endpoint** - Use any service that implements the OpenAI API
+  - **Codex CLI** - Use your existing Codex CLI login and subscription. No API key required.
+  - **Claude CLI** - Use your existing Claude Code login and subscription. No API key required.
 
   Together AI, OpenAI, xAI, and LM Studio models use the agentic generation
   flow. Tested Together models without compatible tool calls use the one-shot
@@ -62,7 +64,7 @@ This will guide you through:
 
   > **Note:** When using environment variables, ensure all related variables (e.g., `OPENAI_API_KEY` and `OPENAI_BASE_URL`) are set consistently to avoid configuration mismatches with the config file.
 
-  This will create a `.aicommits` file in your home directory.
+This will create a `.aicommits` file in your home directory. When you select Codex CLI or Claude CLI, `aicommits` uses the locally installed and logged-in command.
 
 ### Upgrading
 
@@ -330,7 +332,15 @@ Model to use for OpenAI-compatible providers.
 
 #### provider
 
-The selected AI provider. Set automatically during `aicommits setup`. Valid values: `openai`, `togetherai`, `groq`, `xai`, `openrouter`, `ollama`, `lmstudio`, `custom`.
+The selected AI provider. Set automatically during `aicommits setup`. Valid values: `openai`, `togetherai`, `groq`, `xai`, `openrouter`, `ollama`, `lmstudio`, `custom`, `codex`, `claude`.
+
+#### prompt
+
+Optional default instructions added to every generated commit message. Command-line `--prompt` values override this setting for one run.
+
+```sh
+aicommits config set prompt="Use a concise imperative subject and mention the affected user workflow."
+```
 
 #### locale
 

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -15,7 +15,9 @@ import {
 	getDetectedMessage,
 } from '../utils/git.js';
 import { getConfig, setConfigs } from '../utils/config-runtime.js';
-import { getProvider } from '../feature/providers/index.js';
+import { getProvider, isClaudeProvider, isCodexProvider } from '../feature/providers/index.js';
+import { generateClaudeCommitMessage } from '../feature/claude.js';
+import { generateCodexCommitMessage } from '../feature/codex.js';
 import {
 	formatCommitMessage,
 	generateCommitMessage,
@@ -81,6 +83,7 @@ export default async (
 		const config = await getConfig({
 			generate: generate?.toString(),
 			type: commitType?.toString(),
+			prompt: customPrompt,
 		});
 
 		const providerInstance = getProvider(config);
@@ -116,7 +119,6 @@ export default async (
 		const generationCount = requiresBody ? 1 : config.generate;
 
 		const attemptGeneration = async () => {
-			const model = providerInstance.getGenerationModel(config.model!);
 			const s = headless ? null : spinner();
 			if (s) {
 				s.start(
@@ -127,6 +129,52 @@ export default async (
 			}
 			const startTime = Date.now();
 			try {
+				if (isCodexProvider(providerInstance)) {
+					const { stdout: diff } = await execa(
+						'git',
+						['--literal-pathspecs', 'diff', '--cached', '--diff-algorithm=minimal', '--', ...stagedFiles],
+						{ cwd: gitRoot, timeout }
+					);
+					const results = await Promise.all(
+						Array.from({ length: generationCount }, () =>
+							generateCodexCommitMessage({
+								cwd: gitRoot,
+								diff,
+								type: config.type,
+								locale: config.locale,
+								maxLength: config['max-length'],
+								includeBody,
+								timeout,
+								customPrompt: config.prompt,
+							})
+						)
+					);
+					return Array.from(new Set(results.map(formatCommitMessage)));
+				}
+				if (isClaudeProvider(providerInstance)) {
+					const { stdout: diff } = await execa(
+						'git',
+						['--literal-pathspecs', 'diff', '--cached', '--diff-algorithm=minimal', '--', ...stagedFiles],
+						{ cwd: gitRoot, timeout }
+					);
+					const results = await Promise.all(
+						Array.from({ length: generationCount }, () =>
+							generateClaudeCommitMessage({
+								cwd: gitRoot,
+								diff,
+								type: config.type,
+								locale: config.locale,
+								maxLength: config['max-length'],
+								includeBody,
+								timeout,
+								customPrompt: config.prompt,
+							})
+						)
+					);
+					return Array.from(new Set(results.map(formatCommitMessage)));
+				}
+
+				const model = providerInstance.getGenerationModel(config.model!);
 				const results = await Promise.all(
 					Array.from({ length: generationCount }, () =>
 						generateCommitMessage({
@@ -138,7 +186,7 @@ export default async (
 							maxLength: config['max-length'],
 							includeBody,
 							timeout,
-							customPrompt,
+							customPrompt: config.prompt,
 						})
 					)
 				);

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -51,6 +51,11 @@ export default command(
 				return;
 			}
 
+			if (provider.name === 'codex' || provider.name === 'claude') {
+				outro(`${provider.displayName} uses the model configured in its CLI.`);
+				return;
+			}
+
 			// Select model using provider
 			const selectedModel = await selectModel(
 				provider.getBaseUrl(),

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -4,6 +4,10 @@ import { black, green, red, bgCyan } from 'kolorist';
 import { assertGitRepo, getStagedFiles } from '../utils/git.js';
 import { getConfig } from '../utils/config-runtime.js';
 import { getProvider } from '../feature/providers/index.js';
+import { isClaudeProvider, isCodexProvider } from '../feature/providers/index.js';
+import { generateClaudeCommitMessage } from '../feature/claude.js';
+import { generateCodexCommitMessage } from '../feature/codex.js';
+import { execa } from 'execa';
 import {
 	formatCommitMessage,
 	generateCommitMessage,
@@ -62,7 +66,6 @@ export default () =>
 
 		// Use the unified model or provider default
 		const modelName = config.OPENAI_MODEL || providerInstance.getDefaultModel();
-		const model = providerInstance.getGenerationModel(modelName);
 		const { requiresBody } = getCommitTypePolicy(config.type);
 		const generationCount = requiresBody ? 1 : config.generate;
 
@@ -70,6 +73,50 @@ export default () =>
 		s?.start('The AI is analyzing your changes');
 		let messages: string[];
 		try {
+			if (isCodexProvider(providerInstance)) {
+				const { stdout: diff } = await execa(
+					'git',
+					['--literal-pathspecs', 'diff', '--cached', '--diff-algorithm=minimal', '--', ...stagedFiles],
+					{ cwd: gitRoot, timeout }
+				);
+				const results = await Promise.all(
+					Array.from({ length: generationCount }, () =>
+						generateCodexCommitMessage({
+							cwd: gitRoot,
+								diff,
+								type: config.type,
+								locale: config.locale,
+								maxLength: config['max-length'],
+								includeBody: requiresBody,
+								timeout,
+								customPrompt: config.prompt,
+							})
+					)
+				);
+				messages = results.map(formatCommitMessage);
+			} else if (isClaudeProvider(providerInstance)) {
+				const { stdout: diff } = await execa(
+					'git',
+					['--literal-pathspecs', 'diff', '--cached', '--diff-algorithm=minimal', '--', ...stagedFiles],
+					{ cwd: gitRoot, timeout }
+				);
+				const results = await Promise.all(
+					Array.from({ length: generationCount }, () =>
+						generateClaudeCommitMessage({
+							cwd: gitRoot,
+							diff,
+							type: config.type,
+							locale: config.locale,
+							maxLength: config['max-length'],
+							includeBody: requiresBody,
+							timeout,
+							customPrompt: config.prompt,
+						})
+					)
+				);
+				messages = results.map(formatCommitMessage);
+			} else {
+				const model = providerInstance.getGenerationModel(modelName);
 			const results = await Promise.all(
 				Array.from({ length: generationCount }, () =>
 					generateCommitMessage({
@@ -85,6 +132,7 @@ export default () =>
 				)
 			);
 			messages = results.map(({ message }) => formatCommitMessage(message));
+			}
 		} finally {
 			s?.stop('Changes analyzed');
 		}

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -105,14 +105,14 @@ export default command(
 				return;
 			}
 
-			// Select model interactively
-			const { selectModel } = await import('../feature/models.js');
-			const selectedModel = await selectModel(
-				provider.getBaseUrl(),
-				provider.getApiKey() || '',
-				undefined,
-				provider.getDefinition()
-			);
+			const selectedModel = provider.name === 'codex' || provider.name === 'claude'
+				? provider.getDefaultModel()
+				: await (await import('../feature/models.js')).selectModel(
+					provider.getBaseUrl(),
+					provider.getApiKey() || '',
+					undefined,
+					provider.getDefinition()
+				);
 
 			if (selectedModel) {
 				config.OPENAI_MODEL = selectedModel;

--- a/src/feature/claude.ts
+++ b/src/feature/claude.ts
@@ -1,0 +1,62 @@
+import { execa } from 'execa';
+import { KnownError } from '../utils/error.js';
+import { parseCommitMessage, type CommitMessage } from './generate-commit-message.js';
+import type { CommitType } from '../utils/config-types.js';
+
+type Options = {
+	cwd: string;
+	diff: string;
+	type: CommitType;
+	locale: string;
+	maxLength: number;
+	includeBody: boolean;
+	timeout: number;
+	customPrompt?: string;
+};
+
+const formatFor = (type: CommitType) =>
+	type === 'conventional' || type === 'conventional+body'
+		? 'Conventional Commits: <type>(optional scope): <subject>'
+		: type === 'gitmoji'
+			? 'Gitmoji: <emoji> <subject>'
+			: 'plain text';
+
+const buildPrompt = ({ type, locale, maxLength, includeBody, customPrompt }: Options) =>
+	[
+		'Generate one accurate Git commit message using only the staged diff attached on stdin.',
+		'Return only the commit message. Do not use Markdown, explanations, or code fences.',
+		'Mention the important behavior change, not file names.',
+		`Write in ${locale}. Format: ${formatFor(type)}.`,
+		`Prefer a concise subject around ${maxLength} characters, but finish the thought.`,
+		includeBody
+			? 'Return a concise non-empty body after one blank line.'
+			: 'Return a subject only, with no body.',
+		'Never end the subject with an ellipsis.',
+		customPrompt,
+	]
+		.filter(Boolean)
+		.join('\n');
+
+export const generateClaudeCommitMessage = async (options: Options): Promise<CommitMessage> => {
+	try {
+		const { stdout } = await execa(
+			'claude',
+			[
+				'--print', '--no-session-persistence', '--tools', '', '--output-format', 'json',
+				buildPrompt(options),
+			],
+			{ cwd: options.cwd, input: options.diff, timeout: options.timeout }
+		);
+		const result = JSON.parse(stdout) as { result?: unknown; is_error?: boolean };
+		if (result.is_error || typeof result.result !== 'string') {
+			throw new KnownError('Claude CLI did not return a commit message.');
+		}
+		return parseCommitMessage(result.result, options.includeBody);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (/command not found|ENOENT/.test(message)) {
+			throw new KnownError('Claude CLI was not found. Install Claude Code and sign in, then try again.');
+		}
+		throw error;
+	}
+};

--- a/src/feature/codex.ts
+++ b/src/feature/codex.ts
@@ -1,0 +1,65 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { execa } from 'execa';
+import { KnownError } from '../utils/error.js';
+import { parseCommitMessage, type CommitMessage } from './generate-commit-message.js';
+import type { CommitType } from '../utils/config-types.js';
+
+type Options = {
+	cwd: string;
+	diff: string;
+	type: CommitType;
+	locale: string;
+	maxLength: number;
+	includeBody: boolean;
+	timeout: number;
+	customPrompt?: string;
+};
+
+const formatFor = (type: CommitType) =>
+	type === 'conventional' || type === 'conventional+body'
+		? 'Conventional Commits: <type>(optional scope): <subject>'
+		: type === 'gitmoji'
+			? 'Gitmoji: <emoji> <subject>'
+			: 'plain text';
+
+const buildPrompt = ({ type, locale, maxLength, includeBody, customPrompt }: Options) =>
+	[
+		'Generate one accurate Git commit message using only the staged diff attached on stdin.',
+		'Return only the commit message. Do not use Markdown, explanations, or code fences.',
+		'Mention the important behavior change, not file names.',
+		`Write in ${locale}. Format: ${formatFor(type)}.`,
+		`Prefer a concise subject around ${maxLength} characters, but finish the thought.`,
+		includeBody
+			? 'Return a concise non-empty body after one blank line.'
+			: 'Return a subject only, with no body.',
+		'Never end the subject with an ellipsis.',
+		customPrompt,
+	]
+		.filter(Boolean)
+		.join('\n');
+
+export const generateCodexCommitMessage = async (options: Options): Promise<CommitMessage> => {
+	const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'aicommits-codex-'));
+	const outputPath = path.join(tempDirectory, 'message.txt');
+	try {
+		await execa(
+			'codex',
+			[
+				'exec', '--ephemeral', '--sandbox', 'read-only', '--output-last-message', outputPath,
+				buildPrompt(options),
+			],
+			{ cwd: options.cwd, input: options.diff, timeout: options.timeout }
+		);
+		return parseCommitMessage(await fs.readFile(outputPath, 'utf8'), options.includeBody);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (/command not found|ENOENT/.test(message)) {
+			throw new KnownError('Codex CLI was not found. Install Codex and run `codex login`, then try again.');
+		}
+		throw error;
+	} finally {
+		await fs.rm(tempDirectory, { recursive: true, force: true });
+	}
+};

--- a/src/feature/generate-commit-message.ts
+++ b/src/feature/generate-commit-message.ts
@@ -496,7 +496,7 @@ const validateSubject = (subject: string) => {
 	return normalizedSubject;
 };
 
-const parseOneShotMessage = (
+export const parseCommitMessage = (
 	text: string,
 	includeBody: boolean
 ): CommitMessage => {
@@ -625,7 +625,7 @@ export const generateCommitMessage = async ({
 			results.push(result);
 			try {
 				return {
-					message: parseOneShotMessage(
+					message: parseCommitMessage(
 						result.text,
 						oneShotIncludeBody
 					),

--- a/src/feature/providers/claude.ts
+++ b/src/feature/providers/claude.ts
@@ -1,0 +1,10 @@
+import type { ProviderDef } from './base.js';
+
+export const ClaudeProvider: ProviderDef = {
+	name: 'claude',
+	displayName: 'Claude CLI (uses your Claude subscription)',
+	baseUrl: 'claude://cli',
+	defaultModels: ['claude'],
+	defaultTimeout: 120_000,
+	requiresApiKey: false,
+};

--- a/src/feature/providers/codex.ts
+++ b/src/feature/providers/codex.ts
@@ -1,0 +1,10 @@
+import type { ProviderDef } from './base.js';
+
+export const CodexProvider: ProviderDef = {
+	name: 'codex',
+	displayName: 'Codex CLI (uses your Codex subscription)',
+	baseUrl: 'codex://cli',
+	defaultModels: ['codex'],
+	defaultTimeout: 120_000,
+	requiresApiKey: false,
+};

--- a/src/feature/providers/index.ts
+++ b/src/feature/providers/index.ts
@@ -27,3 +27,9 @@ export function getProviderBaseUrl(providerName: string): string {
 export function getProviderDef(providerName: string): ProviderDef | undefined {
 	return providers.find((p) => p.name === providerName);
 }
+
+export const isCodexProvider = (provider: Provider): boolean =>
+	provider.name === 'codex';
+
+export const isClaudeProvider = (provider: Provider): boolean =>
+	provider.name === 'claude';

--- a/src/feature/providers/providers-data.ts
+++ b/src/feature/providers/providers-data.ts
@@ -6,12 +6,16 @@ import { OpenRouterProvider } from './openrouter.js';
 import { LMStudioProvider } from './lmstudio.js';
 import { GroqProvider } from './groq.js';
 import { XAiProvider } from './xai.js';
+import { CodexProvider } from './codex.js';
+import { ClaudeProvider } from './claude.js';
 
 export const providers = [
 	TogetherProvider,
 	OpenAiProvider,
 	GroqProvider,
 	XAiProvider,
+	CodexProvider,
+	ClaudeProvider,
 	OllamaProvider,
 	LMStudioProvider,
 	OpenRouterProvider,

--- a/src/utils/config-types.ts
+++ b/src/utils/config-types.ts
@@ -46,6 +46,9 @@ const configParsers = {
 	OPENAI_MODEL(key?: string) {
 		return key || '';
 	},
+	prompt(prompt?: string) {
+		return prompt || '';
+	},
 	locale(locale?: string) {
 		if (!locale) {
 			return 'en';

--- a/tests/specs/providers.ts
+++ b/tests/specs/providers.ts
@@ -22,6 +22,14 @@ export default testSuite(({ describe }) => {
 			expect(createProvider('togetherai').getRequestTimeout()).toBe(60_000);
 		});
 
+		test('uses subscription CLI providers without API keys', () => {
+			for (const name of ['codex', 'claude']) {
+				const provider = createProvider(name);
+				expect(provider.validateConfig()).toEqual({ valid: true, errors: [] });
+				expect(provider.getRequestTimeout()).toBe(120_000);
+			}
+		});
+
 		test('highlights the current xAI models', () => {
 			expect(createProvider('xai').getHighlightedModels()).toEqual([
 				'grok-4.5',


### PR DESCRIPTION
Closes #361

## Summary

- add `codex` and `claude` providers that reuse existing authenticated CLI subscriptions without API keys
- run Codex in an ephemeral read-only sandbox and Claude with tools disabled
- pass staged diffs through stdin and keep aicommits responsible for formatting, confirmation, and commits
- support a persistent `prompt` config with a one-run `--prompt` override
- document setup and add provider configuration coverage

## Validation

- `pnpm type-check`
- `pnpm build`
- `pnpm test` - 73 passed
- manually exercised both providers against a real staged diff
