### PR TITLE
fix: refresh Together models and support Git worktrees

### DIFF
--- a/scripts/benchmark-together-models.ts
+++ b/scripts/benchmark-together-models.ts
@@ -19,6 +19,7 @@ const REPEATS = Number(process.env.AICOMMITS_BENCHMARK_REPEATS || 1);
 
 const defaultModels = [
 	'zai-org/GLM-5.3-Flash',
+	'deepseek-ai/DeepSeek-V4-Flash-0731',
 	'moonshotai/Kimi-K3',
 ];
 

--- a/scripts/benchmark-together-models.ts
+++ b/scripts/benchmark-together-models.ts
@@ -18,8 +18,8 @@ const TIMEOUT = Number(process.env.AICOMMITS_BENCHMARK_TIMEOUT || 60_000);
 const REPEATS = Number(process.env.AICOMMITS_BENCHMARK_REPEATS || 1);
 
 const defaultModels = [
-	'zai-org/GLM-5.3-Flash',
 	'deepseek-ai/DeepSeek-V4-Flash-0731',
+	'zai-org/GLM-5.3-Flash',
 	'moonshotai/Kimi-K3',
 ];
 

--- a/scripts/benchmark-together-models.ts
+++ b/scripts/benchmark-together-models.ts
@@ -18,11 +18,11 @@ const TIMEOUT = Number(process.env.AICOMMITS_BENCHMARK_TIMEOUT || 60_000);
 const REPEATS = Number(process.env.AICOMMITS_BENCHMARK_REPEATS || 1);
 
 const defaultModels = [
-	'moonshotai/Kimi-K2.7-Code',
-	'zai-org/GLM-5.2',
-	'moonshotai/Kimi-K2.6',
+	'zai-org/GLM-5.3-Flash',
+	'zai-org/GLM-5.3',
 	'MiniMaxAI/MiniMax-M3',
 	'moonshotai/Kimi-K3',
+	'zai-org/GLM-5.2',
 	'google/gemma-4-31B-it',
 	'openai/gpt-oss-20b',
 	'Qwen/Qwen3.5-9B',
@@ -308,6 +308,18 @@ const main = async () => {
 	const provider = getProvider(config);
 	if (!provider || provider.name !== 'togetherai') {
 		throw new Error('Benchmark requires a configured Together AI provider.');
+	}
+	const catalog = await provider.getModels();
+	if (catalog.error) {
+		throw new Error(`Could not load Together serverless models: ${catalog.error}`);
+	}
+	const unavailableModels = models.filter(
+		(model) => !catalog.models.includes(model)
+	);
+	if (unavailableModels.length > 0) {
+		throw new Error(
+			`Models are not available on Together serverless: ${unavailableModels.join(', ')}`
+		);
 	}
 
 	const legacy = await loadLegacyRuntime();

--- a/scripts/benchmark-together-models.ts
+++ b/scripts/benchmark-together-models.ts
@@ -19,15 +19,7 @@ const REPEATS = Number(process.env.AICOMMITS_BENCHMARK_REPEATS || 1);
 
 const defaultModels = [
 	'zai-org/GLM-5.3-Flash',
-	'zai-org/GLM-5.3',
-	'MiniMaxAI/MiniMax-M3',
 	'moonshotai/Kimi-K3',
-	'zai-org/GLM-5.2',
-	'google/gemma-4-31B-it',
-	'openai/gpt-oss-20b',
-	'Qwen/Qwen3.5-9B',
-	'meta-llama/Llama-3.3-70B-Instruct-Turbo',
-	'openai/gpt-oss-120b',
 ];
 
 const smallFixtures = [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,7 +117,7 @@ cli(
 			process.exit(0);
 		}
 
-		if (isCalledFromGitHook) {
+		if (isCalledFromGitHook()) {
 			prepareCommitMessageHook();
 		} else {
 			aicommits(

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -159,9 +159,12 @@ export default async (
 		try {
 			messages = await attemptGeneration();
 		} catch (error) {
-			if (!isModelUnavailableError(error)) throw error;
-			const fallbackModel = providerInstance.getDefaultModel();
-			if (!fallbackModel || fallbackModel === config.model) {
+			const modelUnavailable = isModelUnavailableError(error);
+			const fallbackModel =
+				providerInstance.getFallbackModel(config.model!) ||
+				(modelUnavailable ? providerInstance.getDefaultModel() : undefined);
+			if (!fallbackModel) throw error;
+			if (fallbackModel === config.model) {
 				throw new KnownError(
 					`Model "${config.model}" is not available or has been deprecated.`
 				);
@@ -170,12 +173,14 @@ export default async (
 			if (!headless) {
 				console.log(
 					yellow(
-						`⚠ Model "${config.model}" is unavailable. Switching to "${fallbackModel}".`
+						`⚠ Model "${config.model}" failed. Retrying with "${fallbackModel}".`
 					)
 				);
 			}
 			config.model = fallbackModel;
-			await setConfigs([['OPENAI_MODEL', fallbackModel]]);
+			if (modelUnavailable) {
+				await setConfigs([['OPENAI_MODEL', fallbackModel]]);
+			}
 			messages = await attemptGeneration();
 		}
 

--- a/src/commands/hook.ts
+++ b/src/commands/hook.ts
@@ -3,18 +3,16 @@ import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { green, red } from 'kolorist';
 import { command } from 'cleye';
-import { assertGitRepo } from '../utils/git.js';
+import { getGitHooksPath } from '../utils/git.js';
 import { fileExists } from '../utils/fs.js';
 import { KnownError, handleCliError } from '../utils/error.js';
 
 const hookName = 'prepare-commit-msg';
-const symlinkPath = `.git/hooks/${hookName}`;
 
 const hookPath = fileURLToPath(new URL('cli.mjs', import.meta.url));
 
-export const isCalledFromGitHook = process.argv[1]
-	.replace(/\\/g, '/') // Replace Windows back slashes with forward slashes
-	.endsWith(`/${symlinkPath}`);
+export const isCalledFromGitHook = (scriptPath = process.argv[1]) =>
+	path.posix.basename(scriptPath.replace(/\\/g, '/')) === hookName;
 
 const isWindows = process.platform === 'win32';
 const windowsHook = `
@@ -33,17 +31,17 @@ export default command(
 	},
 	(argv) => {
 		(async () => {
-			const gitRepoPath = await assertGitRepo();
+			const gitHooksPath = await getGitHooksPath();
 			const { installUninstall: mode } = argv._;
 
-			const absoltueSymlinkPath = path.join(gitRepoPath, symlinkPath);
-			const hookExists = await fileExists(absoltueSymlinkPath);
+			const absoluteSymlinkPath = path.join(gitHooksPath, hookName);
+			const hookExists = await fileExists(absoluteSymlinkPath);
 			if (mode === 'install') {
 				if (hookExists) {
 					// If the symlink is broken, it will throw an error
 					// eslint-disable-next-line @typescript-eslint/no-empty-function
 					const realpath = await fs
-						.realpath(absoltueSymlinkPath)
+						.realpath(absoluteSymlinkPath)
 						.catch(() => {});
 					if (realpath === hookPath) {
 						console.warn('The hook is already installed');
@@ -54,13 +52,13 @@ export default command(
 					);
 				}
 
-				await fs.mkdir(path.dirname(absoltueSymlinkPath), { recursive: true });
+				await fs.mkdir(path.dirname(absoluteSymlinkPath), { recursive: true });
 
 				if (isWindows) {
-					await fs.writeFile(absoltueSymlinkPath, windowsHook);
+					await fs.writeFile(absoluteSymlinkPath, windowsHook);
 				} else {
-					await fs.symlink(hookPath, absoltueSymlinkPath, 'file');
-					await fs.chmod(absoltueSymlinkPath, 0o755);
+					await fs.symlink(hookPath, absoluteSymlinkPath, 'file');
+					await fs.chmod(absoluteSymlinkPath, 0o755);
 				}
 				console.log(`${green('✔')} Hook installed`);
 				return;
@@ -73,20 +71,20 @@ export default command(
 				}
 
 				if (isWindows) {
-					const scriptContent = await fs.readFile(absoltueSymlinkPath, 'utf8');
+					const scriptContent = await fs.readFile(absoluteSymlinkPath, 'utf8');
 					if (scriptContent !== windowsHook) {
 						console.warn('Hook is not installed');
 						return;
 					}
 				} else {
-					const realpath = await fs.realpath(absoltueSymlinkPath);
+					const realpath = await fs.realpath(absoluteSymlinkPath);
 					if (realpath !== hookPath) {
 						console.warn('Hook is not installed');
 						return;
 					}
 				}
 
-				await fs.rm(absoltueSymlinkPath);
+				await fs.rm(absoluteSymlinkPath);
 				console.log(`${green('✔')} Hook uninstalled`);
 				return;
 			}

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -61,15 +61,11 @@ export default () =>
 		const timeout = providerInstance.getRequestTimeout(config.timeout);
 
 		// Use the unified model or provider default
-		const modelName = config.OPENAI_MODEL || providerInstance.getDefaultModel();
-		const model = providerInstance.getGenerationModel(modelName);
+		let modelName = config.OPENAI_MODEL || providerInstance.getDefaultModel();
 		const { requiresBody } = getCommitTypePolicy(config.type);
 		const generationCount = requiresBody ? 1 : config.generate;
-
-		const s = headless ? null : spinner();
-		s?.start('The AI is analyzing your changes');
-		let messages: string[];
-		try {
+		const attemptGeneration = async () => {
+			const model = providerInstance.getGenerationModel(modelName);
 			const results = await Promise.all(
 				Array.from({ length: generationCount }, () =>
 					generateCommitMessage({
@@ -84,7 +80,21 @@ export default () =>
 					})
 				)
 			);
-			messages = results.map(({ message }) => formatCommitMessage(message));
+			return results.map(({ message }) => formatCommitMessage(message));
+		};
+
+		const s = headless ? null : spinner();
+		s?.start('The AI is analyzing your changes');
+		let messages: string[];
+		try {
+			try {
+				messages = await attemptGeneration();
+			} catch (error) {
+				const fallbackModel = providerInstance.getFallbackModel(modelName);
+				if (!fallbackModel) throw error;
+				modelName = fallbackModel;
+				messages = await attemptGeneration();
+			}
 		} finally {
 			s?.stop('Changes analyzed');
 		}

--- a/src/feature/models.ts
+++ b/src/feature/models.ts
@@ -72,14 +72,21 @@ interface FetchModelsOptions {
 	baseUrl: string;
 	apiKey?: string;
 	cacheModels?: boolean;
+	modelsPath?: string;
 }
 
 // Fetch models from API
 export const fetchModels = async (
 	options: FetchModelsOptions,
 ): Promise<{ models: ModelObject[]; error?: string }> => {
-	const { baseUrl, apiKey = '', cacheModels = true } = options;
-	const cacheKey = getCacheKey(baseUrl);
+	const {
+		baseUrl,
+		apiKey = '',
+		cacheModels = true,
+		modelsPath = '/models',
+	} = options;
+	const modelsUrl = `${baseUrl}${modelsPath}`;
+	const cacheKey = getCacheKey(modelsUrl);
 	const now = Date.now();
 
 	if (cacheModels) {
@@ -90,7 +97,7 @@ export const fetchModels = async (
 	}
 
 	try {
-		const response = await fetch(`${baseUrl}/models`, {
+		const response = await fetch(modelsUrl, {
 			headers: {
 				Authorization: `Bearer ${apiKey}`,
 			},
@@ -129,6 +136,7 @@ const fetchAndFilterModels = async (
 		baseUrl,
 		apiKey,
 		cacheModels: providerDef?.cacheModels,
+		modelsPath: providerDef?.modelsPath,
 	});
 
 	if (result.error) {

--- a/src/feature/providers/base.ts
+++ b/src/feature/providers/base.ts
@@ -154,9 +154,11 @@ export class Provider {
 	}
 
 	getFallbackModel(model: string): string | undefined {
-		return this.def.fallbackModel !== model
-			? this.def.fallbackModel
-			: undefined;
+		if (!this.def.fallbackModel) return;
+		if (this.def.fallbackModel !== model) {
+			return this.def.fallbackModel;
+		}
+		return this.def.defaultModels.find((candidate) => candidate !== model);
 	}
 
 	getHighlightedModels(): string[] {

--- a/src/feature/providers/base.ts
+++ b/src/feature/providers/base.ts
@@ -23,8 +23,10 @@ export type ProviderDef = {
 	displayName: string;
 	baseUrl: string;
 	apiKeyFormat?: string;
+	modelsPath?: string;
 	modelsFilter?: (models: any[]) => string[];
 	defaultModels: string[];
+	fallbackModel?: string;
 	defaultTimeout?: number;
 	requiresApiKey: boolean;
 	headers?: Record<string, string>;
@@ -120,6 +122,7 @@ export class Provider {
 			baseUrl,
 			apiKey,
 			cacheModels: this.def.cacheModels,
+			modelsPath: this.def.modelsPath,
 		});
 		if (result.error) return { models: [], error: result.error };
 
@@ -148,6 +151,12 @@ export class Provider {
 
 	getDefaultModel(): string {
 		return this.def.defaultModels[0] || '';
+	}
+
+	getFallbackModel(model: string): string | undefined {
+		return this.def.fallbackModel !== model
+			? this.def.fallbackModel
+			: undefined;
 	}
 
 	getHighlightedModels(): string[] {

--- a/src/feature/providers/together.ts
+++ b/src/feature/providers/together.ts
@@ -11,6 +11,7 @@ export const TOGETHER_NON_AGENTIC_MODELS = new Set([
 	'openai/gpt-oss-20b',
 	'pearl-ai/gemma-4-31b-it',
 	'Qwen/Qwen2.5-7B-Instruct-Turbo',
+	'moonshotai/Kimi-K3',
 ]);
 
 const TOGETHER_REASONING_ONLY_MODELS = new Set([
@@ -39,6 +40,7 @@ export const TogetherProvider: ProviderDef = {
 	displayName: 'Together AI (recommended)',
 	baseUrl: 'https://api.together.xyz/v1',
 	apiKeyFormat: 'tgp_',
+	modelsPath: '/models?serverless=true',
 	modelsFilter: (models) =>
 		models
 			.filter(
@@ -48,9 +50,10 @@ export const TogetherProvider: ProviderDef = {
 			)
 			.map((m: any) => m.id),
 	defaultModels: [
-		'zai-org/GLM-5.2',
+		'zai-org/GLM-5.3-Flash',
 		'moonshotai/Kimi-K3',
 	],
+	fallbackModel: 'zai-org/GLM-5.3-Flash',
 	defaultTimeout: 60_000,
 	requiresApiKey: true,
 	agenticGeneration: {

--- a/src/feature/providers/together.ts
+++ b/src/feature/providers/together.ts
@@ -51,6 +51,7 @@ export const TogetherProvider: ProviderDef = {
 			.map((m: any) => m.id),
 	defaultModels: [
 		'zai-org/GLM-5.3-Flash',
+		'deepseek-ai/DeepSeek-V4-Flash-0731',
 		'moonshotai/Kimi-K3',
 	],
 	fallbackModel: 'zai-org/GLM-5.3-Flash',

--- a/src/feature/providers/together.ts
+++ b/src/feature/providers/together.ts
@@ -50,11 +50,11 @@ export const TogetherProvider: ProviderDef = {
 			)
 			.map((m: any) => m.id),
 	defaultModels: [
-		'zai-org/GLM-5.3-Flash',
 		'deepseek-ai/DeepSeek-V4-Flash-0731',
+		'zai-org/GLM-5.3-Flash',
 		'moonshotai/Kimi-K3',
 	],
-	fallbackModel: 'zai-org/GLM-5.3-Flash',
+	fallbackModel: 'deepseek-ai/DeepSeek-V4-Flash-0731',
 	defaultTimeout: 60_000,
 	requiresApiKey: true,
 	agenticGeneration: {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -15,6 +15,20 @@ export const assertGitRepo = async () => {
 	return stdout;
 };
 
+export const getGitHooksPath = async () => {
+	const { stdout, failed } = await execa(
+		'git',
+		['rev-parse', '--path-format=absolute', '--git-path', 'hooks'],
+		{ reject: false }
+	);
+
+	if (failed) {
+		throw new KnownError('The current directory must be a Git repository!');
+	}
+
+	return stdout;
+};
+
 const excludeFromDiff = (path: string) => `:(exclude)${path}`;
 
 const lockFilePatterns = [

--- a/tests/specs/generate-commit-message.ts
+++ b/tests/specs/generate-commit-message.ts
@@ -107,8 +107,8 @@ export default testSuite(({ describe }) => {
 			);
 			expect(TOGETHER_NON_AGENTIC_MODELS.size).toBe(9);
 			expect(TogetherProvider.defaultModels).toEqual([
-				'zai-org/GLM-5.3-Flash',
 				'deepseek-ai/DeepSeek-V4-Flash-0731',
+				'zai-org/GLM-5.3-Flash',
 				'moonshotai/Kimi-K3',
 			]);
 		});

--- a/tests/specs/generate-commit-message.ts
+++ b/tests/specs/generate-commit-message.ts
@@ -93,6 +93,9 @@ export default testSuite(({ describe }) => {
 	describe('generateCommitMessage', ({ test }) => {
 		test('keeps unknown Together models agentic by default', () => {
 			expect(supportsTogetherAgenticGeneration('future/model')).toBe(true);
+			expect(supportsTogetherAgenticGeneration('moonshotai/Kimi-K3')).toBe(
+				false
+			);
 			expect(
 				supportsTogetherAgenticGeneration('openai/gpt-oss-20b')
 			).toBe(false);
@@ -102,9 +105,9 @@ export default testSuite(({ describe }) => {
 			expect(supportsTogetherAgenticGeneration('thinkingmachines/Inkling')).toBe(
 				true
 			);
-			expect(TOGETHER_NON_AGENTIC_MODELS.size).toBe(8);
+			expect(TOGETHER_NON_AGENTIC_MODELS.size).toBe(9);
 			expect(TogetherProvider.defaultModels).toEqual([
-				'zai-org/GLM-5.2',
+				'zai-org/GLM-5.3-Flash',
 				'moonshotai/Kimi-K3',
 			]);
 		});
@@ -644,7 +647,7 @@ export default testSuite(({ describe }) => {
 			await git('add', ['file.txt']);
 			const model = new MockLanguageModelV4({
 				provider: 'togetherai.chat',
-				modelId: 'moonshotai/Kimi-K3',
+				modelId: 'future/tool-model',
 				doStream: [
 					toolCallStream('empty-message-1', 'submitCommitMessage', {
 						subject: '   ',
@@ -682,7 +685,7 @@ export default testSuite(({ describe }) => {
 			await git('add', ['file.txt']);
 			const model = new MockLanguageModelV4({
 				provider: 'togetherai.chat',
-				modelId: 'moonshotai/Kimi-K3',
+				modelId: 'future/tool-model',
 				doStream: [
 					toolCallStream('clipped-message-1', 'submitCommitMessage', {
 						subject: 'fix: update…\nextra prose',

--- a/tests/specs/generate-commit-message.ts
+++ b/tests/specs/generate-commit-message.ts
@@ -108,6 +108,7 @@ export default testSuite(({ describe }) => {
 			expect(TOGETHER_NON_AGENTIC_MODELS.size).toBe(9);
 			expect(TogetherProvider.defaultModels).toEqual([
 				'zai-org/GLM-5.3-Flash',
+				'deepseek-ai/DeepSeek-V4-Flash-0731',
 				'moonshotai/Kimi-K3',
 			]);
 		});

--- a/tests/specs/git-hook.ts
+++ b/tests/specs/git-hook.ts
@@ -5,15 +5,19 @@ import {
 	createGit,
 	files,
 } from '../utils.js';
+import { isCalledFromGitHook } from '../../src/commands/hook.js';
 
 export default testSuite(({ describe }) => {
 	describe('Git hook', ({ test }) => {
-		if (!process.env.OPENAI_API_KEY) {
-			console.warn(
-				'⚠️  process.env.OPENAI_API_KEY is necessary to run these tests. Skipping...'
+		test('recognizes hook paths across platforms', () => {
+			expect(isCalledFromGitHook('/repo/.git/hooks/prepare-commit-msg')).toBe(
+				true
 			);
-			return;
-		}
+			expect(isCalledFromGitHook('C:\\repo\\hooks\\prepare-commit-msg')).toBe(
+				true
+			);
+			expect(isCalledFromGitHook('/repo/hooks/pre-commit')).toBe(false);
+		});
 
 		test('errors when not in Git repo', async () => {
 			const { fixture, aicommits } = await createFixture(files);
@@ -46,7 +50,37 @@ export default testSuite(({ describe }) => {
 			await fixture.rm();
 		});
 
+		test('installs and uninstalls from a linked worktree', async () => {
+			const { fixture, aicommits } = await createFixture(files);
+			const git = await createGit(fixture.path);
+			await git('add', ['.']);
+			await git('commit', ['-m', 'initial', '--no-verify']);
+			const worktreePath = path.join(fixture.path, 'linked-worktree');
+			await git('worktree', ['add', '--detach', worktreePath]);
+
+			const { stdout: installOutput } = await aicommits(['hook', 'install'], {
+				cwd: worktreePath,
+			});
+			expect(installOutput).toMatch('Hook installed');
+			expect(await fixture.exists('.git/hooks/prepare-commit-msg')).toBe(true);
+
+			const { stdout: uninstallOutput } = await aicommits(
+				['hook', 'uninstall'],
+				{ cwd: worktreePath }
+			);
+			expect(uninstallOutput).toMatch('Hook uninstalled');
+			expect(await fixture.exists('.git/hooks/prepare-commit-msg')).toBe(false);
+
+			await fixture.rm();
+		});
+
 		test('Commits', async () => {
+			if (!process.env.OPENAI_API_KEY) {
+				console.warn(
+					'⚠️  process.env.OPENAI_API_KEY is necessary to run this test. Skipping...'
+				);
+				return;
+			}
 			const { fixture, aicommits } = await createFixture(files);
 			const git = await createGit(fixture.path);
 

--- a/tests/specs/providers.ts
+++ b/tests/specs/providers.ts
@@ -55,6 +55,7 @@ export default testSuite(({ describe }) => {
 			const provider = createProvider('togetherai');
 			expect(provider.getHighlightedModels()).toEqual([
 				'zai-org/GLM-5.3-Flash',
+				'deepseek-ai/DeepSeek-V4-Flash-0731',
 				'moonshotai/Kimi-K3',
 			]);
 			expect(provider.getDefaultModel()).toBe('zai-org/GLM-5.3-Flash');

--- a/tests/specs/providers.ts
+++ b/tests/specs/providers.ts
@@ -54,15 +54,22 @@ export default testSuite(({ describe }) => {
 		test('highlights current fast and smart Together models', () => {
 			const provider = createProvider('togetherai');
 			expect(provider.getHighlightedModels()).toEqual([
-				'zai-org/GLM-5.3-Flash',
 				'deepseek-ai/DeepSeek-V4-Flash-0731',
+				'zai-org/GLM-5.3-Flash',
 				'moonshotai/Kimi-K3',
 			]);
-			expect(provider.getDefaultModel()).toBe('zai-org/GLM-5.3-Flash');
-			expect(provider.getFallbackModel('moonshotai/Kimi-K3')).toBe(
-				'zai-org/GLM-5.3-Flash'
+			expect(provider.getDefaultModel()).toBe(
+				'deepseek-ai/DeepSeek-V4-Flash-0731'
 			);
-			expect(provider.getFallbackModel('zai-org/GLM-5.3-Flash')).toBeUndefined();
+			expect(provider.getFallbackModel('moonshotai/Kimi-K3')).toBe(
+				'deepseek-ai/DeepSeek-V4-Flash-0731'
+			);
+			expect(provider.getFallbackModel('zai-org/GLM-5.3-Flash')).toBe(
+				'deepseek-ai/DeepSeek-V4-Flash-0731'
+			);
+			expect(
+				provider.getFallbackModel('deepseek-ai/DeepSeek-V4-Flash-0731')
+			).toBe('zai-org/GLM-5.3-Flash');
 		});
 
 		test('highlights the current xAI models', () => {

--- a/tests/specs/providers.ts
+++ b/tests/specs/providers.ts
@@ -22,6 +22,48 @@ export default testSuite(({ describe }) => {
 			expect(createProvider('togetherai').getRequestTimeout()).toBe(60_000);
 		});
 
+		test('lists only Together serverless models', async () => {
+			const originalFetch = globalThis.fetch;
+			const provider = createProvider('togetherai');
+			const providerDefinition = provider.getDefinition();
+			const originalCacheModels = providerDefinition.cacheModels;
+			const fetchCalls: string[] = [];
+			providerDefinition.cacheModels = false;
+			globalThis.fetch = (async (input: string | URL | Request) => {
+				fetchCalls.push(String(input));
+				return new Response(
+					JSON.stringify([{ id: 'moonshotai/Kimi-K3', type: 'chat' }]),
+					{ status: 200 }
+				);
+			}) as typeof fetch;
+
+			try {
+				expect(await provider.getModels()).toEqual({
+					models: ['moonshotai/Kimi-K3'],
+				});
+			} finally {
+				globalThis.fetch = originalFetch;
+				providerDefinition.cacheModels = originalCacheModels;
+			}
+
+			expect(fetchCalls).toEqual([
+				'https://api.together.xyz/v1/models?serverless=true',
+			]);
+		});
+
+		test('highlights current fast and smart Together models', () => {
+			const provider = createProvider('togetherai');
+			expect(provider.getHighlightedModels()).toEqual([
+				'zai-org/GLM-5.3-Flash',
+				'moonshotai/Kimi-K3',
+			]);
+			expect(provider.getDefaultModel()).toBe('zai-org/GLM-5.3-Flash');
+			expect(provider.getFallbackModel('moonshotai/Kimi-K3')).toBe(
+				'zai-org/GLM-5.3-Flash'
+			);
+			expect(provider.getFallbackModel('zai-org/GLM-5.3-Flash')).toBeUndefined();
+		});
+
 		test('highlights the current xAI models', () => {
 			expect(createProvider('xai').getHighlightedModels()).toEqual([
 				'grok-4.5',
@@ -74,7 +116,7 @@ export default testSuite(({ describe }) => {
 		test('owns generation policy at the provider seam', () => {
 			expect(
 				createProvider('togetherai').getGenerationPolicy('moonshotai/Kimi-K3')
-			).toMatchObject({ mode: 'agentic', isLocal: false });
+			).toMatchObject({ mode: 'fallback', isLocal: false });
 			expect(
 				createProvider('togetherai').getGenerationPolicy(
 					'Qwen/Qwen2.5-7B-Instruct-Turbo'


### PR DESCRIPTION
## Summary

- query Together’s serverless-only model catalog and recommend DeepSeek V4 Flash 0731, GLM 5.3 Flash, and Kimi K3 in that order
- use DeepSeek V4 Flash as the default and preferred fallback target
- fall back from DeepSeek itself to GLM 5.3 Flash so the retry chain never loops
- keep Kimi on the reliable one-shot path after live tool-protocol verification
- reject stale benchmark candidates before starting paid benchmark runs
- resolve Git hook paths through `git rev-parse` so install/uninstall works from linked worktrees and custom hook paths
- detect hook invocation by the exact hook filename across POSIX and Windows paths

## Worktree context

This incorporates the durable worktree fix proposed in #315 while adapting it to the current codebase. It intentionally avoids the broader `scriptPath.includes("/hooks/")` detection from that PR, which could classify unrelated executables as aicommits hooks.

## Live Together verification

- `/models?serverless=true`: 22 callable chat models, no account-specific models
- DeepSeek V4 Flash 0731: callable, passes the two-step protocol in 1.97s, and produced strong messages on all three small benchmark fixtures
- GLM 5.3 Flash: callable and passes the two-step aicommits tool protocol
- Kimi K3: callable; routed through one-shot generation because it did not submit the second required tool call
- Kimi K2.7 Code: catalogued but non-serverless
- Kimi K2.6: no running deployment

DeepSeek V4 Flash averaged about 2.3s across the three candidate benchmark runs versus about 14.9s for GLM 5.3 Flash in this sample. Together lists DeepSeek at $0.14 input / $0.28 output per million tokens.

## Verification

- `pnpm type-check`
- `pnpm build`
- `pnpm test` — 79 passing
- live Together catalog and compatibility checks
- three-fixture DeepSeek V4 Flash versus GLM 5.3 Flash benchmark
- linked-worktree hook install/uninstall integration test