### PR TITLE
fix: increase commit generation token budget

### DIFF
--- a/src/feature/generate-commit-message.ts
+++ b/src/feature/generate-commit-message.ts
@@ -38,6 +38,9 @@ const MAX_AGENT_DIFF_READS = MAX_AGENT_STEPS - 1;
 const MIN_AGENT_DIFF_READ_BYTES = 256;
 const AGENT_ATTEMPTS = 2;
 const ONE_SHOT_ATTEMPTS = 3;
+// Some reasoning models count their internal reasoning against this limit.
+// Leave enough room for the final subject and body after diff analysis.
+const MAX_COMMIT_MESSAGE_OUTPUT_TOKENS = 2048;
 
 export type CommitMessage = {
 	subject: string;
@@ -608,7 +611,7 @@ export const generateCommitMessage = async ({
 						]
 					),
 					prompt,
-					maxOutputTokens: 512,
+					maxOutputTokens: MAX_COMMIT_MESSAGE_OUTPUT_TOKENS,
 					timeout: budget.nextModelTimeout(),
 					...callOptions,
 				});
@@ -830,7 +833,7 @@ export const generateCommitMessage = async ({
 			hasToolCall('submitCommitMessage'),
 			stepCountIs(MAX_AGENT_STEPS),
 		],
-		maxOutputTokens: 512,
+		maxOutputTokens: MAX_COMMIT_MESSAGE_OUTPUT_TOKENS,
 		...callOptions,
 		prepareStep: ({ stepNumber }) => {
 			if (!isLocal && !hasCompleteDiff && stepNumber === 0) {

--- a/tests/specs/generate-commit-message.ts
+++ b/tests/specs/generate-commit-message.ts
@@ -163,6 +163,7 @@ export default testSuite(({ describe }) => {
 			expect(model.doStreamCalls[0].toolChoice).toEqual({
 				type: 'required',
 			});
+			expect(model.doStreamCalls[0].maxOutputTokens).toBe(2048);
 			expect(model.doStreamCalls[0].reasoning).toBe('none');
 			expect(model.doStreamCalls[0].providerOptions).toEqual({
 				togetherai: { reasoning: { enabled: false } },
@@ -901,6 +902,7 @@ export default testSuite(({ describe }) => {
 			expect(result.message.subject).toBe('fix: update fixture value');
 			expect(model.doGenerateCalls.length).toBe(1);
 			expect(model.doStreamCalls.length).toBe(0);
+			expect(model.doGenerateCalls[0].maxOutputTokens).toBe(2048);
 			expect(model.doGenerateCalls[0].tools).toBeUndefined();
 			expect(model.doGenerateCalls[0].reasoning).toBeUndefined();
 			expect(model.doGenerateCalls[0].providerOptions).toBeUndefined();


### PR DESCRIPTION
## Summary
- raise the commit-message generation output budget from 512 to 2048 tokens
- use the same budget for one-shot and agentic generation
- cover both generation paths with assertions

## Motivation
Some reasoning-capable OpenAI-compatible providers, including Gemini 2.5 Flash, can consume the 512-token budget during diff analysis. The provider then returns `finish_reason: length` while the commit body is incomplete.

## Validation
- `pnpm type-check`
- `pnpm test`
- `pnpm build`